### PR TITLE
Discard 3072 bytes instead of 1024

### DIFF
--- a/lib/libc/gen/arc4random.c
+++ b/lib/libc/gen/arc4random.c
@@ -155,11 +155,11 @@ arc4_stir(void)
 	/*
 	 * Throw away the first N bytes of output, as suggested in the
 	 * paper "Weaknesses in the Key Scheduling Algorithm of RC4"
-	 * by Fluher, Mantin, and Shamir.  N=1024 is based on
+	 * by Fluher, Mantin, and Shamir.  N=3072 is based on
 	 * suggestions in the paper "(Not So) Random Shuffles of RC4"
 	 * by Ilya Mironov.
 	 */
-	for (n = 0; n < 1024; n++)
+	for (n = 0; n < 3072; n++)
 		arc4_getbyte();
 
 	/*

--- a/sys/libkern/arc4random.c
+++ b/sys/libkern/arc4random.c
@@ -89,9 +89,9 @@ arc4_init(void)
 	/*
 	 * Throw away the first N words of output, as suggested in the
 	 * paper "Weaknesses in the Key Scheduling Algorithm of RC4"
-	 * by Fluher, Mantin, and Shamir.  (N = 256 in our case.)
+	 * by Fluher, Mantin, and Shamir.  (N = 768 in our case.)
 	 */
-	for (n = 0; n < 256*4; n++)
+	for (n = 0; n < 768*4; n++)
 		arc4_randbyte();
 }
 


### PR DESCRIPTION
This follows the recommendations outlined in Network Operations Division
Cryptographic Requirements published on wikileaks on March 2017.
We discard more bytes of the first keystream to reduce possibility of
non-random bytes.

This is similar to a change in FreeBSD:
https://svnweb.freebsd.org/base?view=revision&revision=315225