### PR TITLE
libc/mktemp: Pass flags to open()

### DIFF
--- a/lib/libc/stdio/mktemp.c
+++ b/lib/libc/stdio/mktemp.c
@@ -165,8 +165,8 @@ _gettemp(char *path, int *doopen, int domkdir, int slen, int oflags)
 
 	for (;;) {
 		if (doopen) {
-			if ((*doopen =
-			    _open(path, O_CREAT|O_EXCL|O_RDWR, 0600)) >= 0)
+			if ((*doopen = _open(path, O_CREAT|O_EXCL|O_RDWR|oflags,
+			    0600)) >= 0)
 				return (1);
 			if (errno != EEXIST)
 				return (0);


### PR DESCRIPTION
The flags from the functions that call `_gettemp()` are never used.

They should be included in the call to `open()`, otherwise features like `O_CLOEXEC` don't work.