### PR TITLE
Adding 'ifconsole' to ttyv entries

### DIFF
--- a/etc/etc.x86_64/ttys
+++ b/etc/etc.x86_64/ttys
@@ -30,15 +30,15 @@
 # when going to single-user mode.
 console	none				unknown	off secure
 #
-ttyv0	"/usr/libexec/getty Pc"		cons25	on  secure
+ttyv0	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
 # Virtual terminals
-ttyv1	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv2	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv3	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv4	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv5	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv6	"/usr/libexec/getty Pc"		cons25	on  secure
-ttyv7	"/usr/libexec/getty Pc"		cons25	on  secure
+ttyv1	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv2	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv3	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv4	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv5	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv6	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
+ttyv7	"/usr/libexec/getty Pc"		cons25	on  secure ifconsole
 ttyv8	"/usr/local/bin/xdm -nodaemon"	xterm	off secure
 # Serial terminals - keep it simple
 #


### PR DESCRIPTION
To prevent spam from getty in /var/log/messages on headless machines in the form of 'getty[...]: open /dev/ttyv0: No such file or directory'