### PR TITLE
Prevent assert() from triggering -Wreturn-type

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -71,7 +71,7 @@
 #endif
 
 __BEGIN_DECLS
-void	__assert(const char *, const char *, int, const char *);
+void	__assert(const char *, const char *, int, const char *) __dead2;
 void	__diagassert(const char *, int, const char *, const char *);
 __END_DECLS
 


### PR DESCRIPTION
See https://github.com/swaywm/wlroots/issues/1700

```c
$ cat a.c
#include <assert.h>
int foo() { assert(0); }

$ gcc8 -Wall -c a.c
a.c: In function 'foo':
a.c:2:1: warning: control reaches end of non-void function [-Wreturn-type]
 int foo() { assert(0); }
 ^~~

$ clang80 -c a.c
a.c:2:24: warning: control reaches end of non-void function [-Wreturn-type]
int foo() { assert(0); }
                       ^
1 warning generated.
```
