### PR TITLE
Fix struct igmpmsg

### DIFF
--- a/sys/net/ip_mroute/ip_mroute.h
+++ b/sys/net/ip_mroute/ip_mroute.h
@@ -295,8 +295,8 @@ struct mfc {
  * note the convenient similarity to an IP packet
  */
 struct igmpmsg {
-    u_long	    unused1;
-    u_long	    unused2;
+    uint32_t	    unused1;
+    uint32_t	    unused2;
     u_char	    im_msgtype;			/* what type of message	    */
 #define IGMPMSG_NOCACHE		1	/* no MFC in the kernel		    */
 #define IGMPMSG_WRONGVIF	2	/* packet came from wrong interface */


### PR DESCRIPTION
struct igmpmsg currently uses u_long to define the unused fields instead of uint32_t. This breaks the mroute api on 64 bit systems, because u_long is 64bit there.
The following code in ip_mroute.c happily corrupts kernel upcall messages on 64bit systems as the fields are incorrectly shifted 8bytes to the right, overwriting the destination ip address in the packet.
/*
* Send message to routing daemon to install
* a route into the kernel table
*/

        im = mtod(mm, struct igmpmsg *);
        im->im_msgtype = IGMPMSG_NOCACHE;
        im->im_mbz = 0;
        im->im_vif = vifi;