### PR TITLE
Flag packets that violate CPU affinity due to firewall re-writes

### DIFF
--- a/sys/net/pf/pf.c
+++ b/sys/net/pf/pf.c
@@ -6570,6 +6570,15 @@ pf_test(int dir, struct ifnet *ifp, struct mbuf **m0,
 	if (m->m_pkthdr.fw_flags & PF_MBUF_TAGGED)
 		return (PF_PASS);
 	m->m_pkthdr.pf.flags = 0;
+	
+	if (m->m_pkthdr.fw_flags & PFIL_WRONG_CPU) {
+		/* Processing on the wrong cpu. Won't cause any issues, as long
+		 * as we put state entries in the global table.
+		 * Can occur on the output side of a nat rule.
+		 */
+		pd.not_cpu_localized = 1;
+	}
+
 	/* Re-Check when updating to > 4.4 */
 	m->m_pkthdr.pf.statekey = NULL;
 

--- a/sys/net/pf/pf.c
+++ b/sys/net/pf/pf.c
@@ -816,11 +816,12 @@ pf_state_key_attach(struct pf_state_key *sk, struct pf_state *s, int idx)
 	KKASSERT(s->key[idx] == NULL);	/* XXX handle this? */
 
 	if (pf_status.debug >= PF_DEBUG_MISC) {
-		kprintf("state_key attach cpu %d (%08x:%d) %s (%08x:%d)\n",
-			cpu,
+		kprintf("state_key attach cpu %d(%d) (%08x:%d) %s (%08x:%d) if: %s\n",
+			cpu, mycpu->gd_cpuid,
 			ntohl(sk->addr[0].addr32[0]), ntohs(sk->port[0]),
 			(idx == PF_SK_WIRE ? "->" : "<-"),
-			ntohl(sk->addr[1].addr32[0]), ntohs(sk->port[1]));
+			ntohl(sk->addr[1].addr32[0]), ntohs(sk->port[1]),
+			s->kif->pfik_name);
 	}
 
 	/*

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -314,6 +314,10 @@ struct mbuf {
 #define FW_MBUF_REDISPATCH	0x00000200
 #define FW_MBUF_PRIVATE1	0x00000400
 #define FW_MBUF_PRIVATE2	0x00000800
+/* When a packet is re-written on input, it may be on the wrong cpu. Flag the
+ * packet so that later processing will know it is on the wrong cpu.
+ */
+#define PFIL_WRONG_CPU		0x00001000
 #define	IPFW_MBUF_GENERATED	FW_MBUF_GENERATED
 
 /*


### PR DESCRIPTION
Currently we just tag packets that are on the wrong CPU. We don't try to move them. Tagging them allows the firewalls to recover. In this case pf creates state entries in the global table rather than the per-cpu table.