### PR TITLE
ip_forward: Migrate cpu if hash doesn't match.

### DIFF
--- a/sys/net/netmsg.h
+++ b/sys/net/netmsg.h
@@ -73,6 +73,7 @@ typedef struct netmsg_base *netmsg_base_t;
  * - netmsg_inarp is embedded in mbufs.
  * - netmsg_ctlinput is embedded in mbufs.
  * - netmsg_genpkt is embedded in mbufs.
+ * - netmsg_forward is embedded in mbufs.
  */
 TAILQ_HEAD(notifymsglist, netmsg_so_notify);
 
@@ -103,6 +104,12 @@ struct netmsg_genpkt {
 	struct mbuf		*m;
 	void			*arg1;
 	u_long			arg2;
+};
+
+struct netmsg_forward {
+	struct netmsg_base	base;
+	struct mbuf		*nm_packet;
+	__boolean_t		using_srcrt;
 };
 
 struct netmsg_pr_timeout {
@@ -300,6 +307,7 @@ union netmsg {
 	struct netmsg_base		base;		/* base embedded */
 
 	struct netmsg_packet		packet;		/* mbuf embedded */
+	struct netmsg_forward		forward;	/* mbuf embedded */
 	struct netmsg_pr_timeout	timeout;
 	struct netmsg_so_notify		notify;
 	struct netmsg_so_notify_abort	notify_abort;

--- a/sys/sys/mbuf.h
+++ b/sys/sys/mbuf.h
@@ -98,6 +98,7 @@ struct m_hdr {
 		struct netmsg_inarp mhm_arp;	/* proto stack arpinput msg */
 		struct netmsg_ctlinput mhm_ctl;	/* proto stack ctlinput msg */
 		struct netmsg_genpkt mhm_gen;	/* generic pkt send/recv msg */
+		struct netmsg_forward mhm_fwd;	/* forwarding msg */
 	} mh_msgu;
 };
 #define mh_netmsg	mh_msgu.mhm_pkt
@@ -105,6 +106,7 @@ struct m_hdr {
 #define mh_arpmsg	mh_msgu.mhm_arp
 #define mh_ctlmsg	mh_msgu.mhm_ctl
 #define mh_genmsg	mh_msgu.mhm_gen
+#define mh_fwdmsg	mh_msgu.mhm_fwd
 
 /* pf stuff */
 struct pkthdr_pf {


### PR DESCRIPTION
Packet filter re-writes can cause the call to ip_forward to be on the wrong CPU. Detect this case and correct it. Check M_HASH at the beginning of ip_input and dispatch to a new CPU if we aren't in the right place. This mirrors what is done for packets that are destined to the transport layer. This causes ip_forward and ip_output to be called on the correct CPU, including any states that are created by output rules.