### PR TITLE
wc: Ignore zero st_size to work on pseudo-filesystems

### DIFF
--- a/usr.bin/wc/wc.c
+++ b/usr.bin/wc/wc.c
@@ -232,7 +232,7 @@ cnt(const char *file)
 				close(fd);
 				return (1);
 			}
-			if (S_ISREG(sb.st_mode)) {
+			if (S_ISREG(sb.st_mode) && sb.st_size > 0) {
 				reset_siginfo();
 				charct = sb.st_size;
 				show_cnt(file, linect, wordct, charct, llct);


### PR DESCRIPTION
`wc -c` fails on  pseudo-filesystems.

To reproduce: `wc -c /proc/$$/status`