### PR TITLE
hexdump: Ignore zero st_size to work on pseudo-filesystems

### DIFF
--- a/usr.bin/hexdump/display.c
+++ b/usr.bin/hexdump/display.c
@@ -335,14 +335,16 @@ doskip(const char *fname)
 
 	if (fstat(fileno(stdin), &sb))
 		err(1, "%s", fname);
-	if (S_ISREG(sb.st_mode) && skip >= sb.st_size) {
-		address += sb.st_size;
-		skip -= sb.st_size;
-	} else if (S_ISREG(sb.st_mode)) {
-		if (fseeko(stdin, skip, SEEK_SET))
-			err(1, "%s", fname);
-		address += skip;
-		skip = 0;
+	if (S_ISREG(sb.st_mode) && sb.st_size > 0) {
+		if (skip >= sb.st_size) {
+			address += sb.st_size;
+			skip -= sb.st_size;
+		} else {
+			if (fseeko(stdin, skip, SEEK_SET))
+				err(1, "%s", fname);
+			address += skip;
+			skip = 0;
+		}
 	} else {
 		for (cnt = 0; cnt < skip; ++cnt)
 			if (getchar() == EOF)


### PR DESCRIPTION
 hexdump(1) is not able to skip on files residing on pseudo-filesystems

To reproduce: `hexdump -s1 /proc/$$/status`

