### PR TITLE
gzip: Set file flags after setting file times

### DIFF
--- a/usr.bin/gzip/gzip.c
+++ b/usr.bin/gzip/gzip.c
@@ -1056,16 +1056,16 @@ copymodes(int fd, const struct stat *sbp, const char *file)
 	if (fchmod(fd, sb.st_mode) < 0)
 		maybe_warn("couldn't fchmod: %s", file);
 
+	TIMESPEC_TO_TIMEVAL(&times[0], &sb.st_atimespec);
+	TIMESPEC_TO_TIMEVAL(&times[1], &sb.st_mtimespec);
+	if (futimes(fd, times) < 0)
+		maybe_warn("couldn't utimes: %s", file);
+
 	/* only try flags if they exist already */
 #ifdef _ST_FLAGS_PRESENT_
         if (sb.st_flags != 0 && fchflags(fd, sb.st_flags) < 0)
 		maybe_warn("couldn't fchflags: %s", file);
 #endif
-
-	TIMESPEC_TO_TIMEVAL(&times[0], &sb.st_atimespec);
-	TIMESPEC_TO_TIMEVAL(&times[1], &sb.st_mtimespec);
-	if (futimes(fd, times) < 0)
-		maybe_warn("couldn't utimes: %s", file);
 }
 #endif
 


### PR DESCRIPTION
 gzip(1) cannot preserve utimes() because it first sets chflags()

```
$ /usr/bin/touch /tmp/foo
$ /bin/chflags uchg /tmp/foo
$ /usr/bin/gzip -v /tmp/foo
gzip: couldn't utimes: /tmp/foo.gz: Operation not permitted
/tmp/foo:         -99.9% -- replaced with /tmp/foo.gz
```