### PR TITLE
cd9660: Add support for mask,dirmask,uid,gid options

### DIFF
--- a/sbin/mount_cd9660/mount_cd9660.8
+++ b/sbin/mount_cd9660/mount_cd9660.8
@@ -33,7 +33,7 @@
 .\" $FreeBSD: src/sbin/mount_cd9660/mount_cd9660.8,v 1.12.2.6 2003/02/24 00:56:41 trhodes Exp $
 .\" $DragonFly: src/sbin/mount_cd9660/mount_cd9660.8,v 1.4 2008/07/27 22:17:48 thomas Exp $
 .\"
-.Dd September 12, 2009
+.Dd March 7, 2024
 .Dt MOUNT_CD9660 8
 .Os
 .Sh NAME
@@ -43,8 +43,12 @@
 .Nm
 .Op Fl begjrv
 .Op Fl C Ar charset
+.Op Fl G Ar gid
+.Op Fl m Ar mask
+.Op Fl M Ar mask
 .Op Fl o Ar options
 .Op Fl s Ar startsector
+.Op Fl U Ar uid
 .Ar special node
 .Sh DESCRIPTION
 The
@@ -70,6 +74,37 @@ Do not strip version numbers on files.
 only the last one will be listed.)
 In either case, files may be opened without explicitly stating a
 version number.
+.It Fl G Ar group
+Set the group of the files in the file system to
+.Ar group .
+The default gid on non-Rockridge volumes is zero.
+.It Fl U Ar user
+Set the owner of the files in the file system to
+.Ar user .
+The default uid on non-Rockridge volumes is zero.
+.It Fl m Ar mask
+Specify the maximum file permissions for files
+in the file system.
+(For example, a
+.Ar mask
+of
+.Li 755
+specifies that, by default, the owner should have
+read, write, and execute permissions for files, but
+others should only have read and execute permissions).
+See
+.Xr chmod 1
+for more information about octal file modes.
+Only the nine low-order bits of
+.Ar mask
+are used.
+The default
+.Ar mask
+on non-Rockridge volumes is 755.
+.It Fl M Ar mask
+Specify the maximum file permissions for directories
+in the file system.
+See the previous option's description for details.
 .It Fl j
 Do not use any Joliet extensions included in the file system.
 .It Fl o

--- a/sbin/mount_cd9660/mount_cd9660.c
+++ b/sbin/mount_cd9660/mount_cd9660.c
@@ -46,10 +46,13 @@
 #include <sys/module.h>
 #include <vfs/isofs/cd9660/cd9660_mount.h>
 
+#include <ctype.h>
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <grp.h>
 #include <mntopts.h>
+#include <pwd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -68,6 +71,9 @@ struct mntopt mopts[] = {
 	MOPT_NULL
 };
 
+static gid_t	a_gid(const char *);
+static uid_t	a_uid(const char *);
+static mode_t	a_mask(const char *);
 static int	get_ssector(const char *dev);
 static void	usage(void);
 int set_charset(struct iso_args *args, const char *cs_local, const char *cs_disk);
@@ -75,18 +81,19 @@ int set_charset(struct iso_args *args, const char *cs_local, const char *cs_disk
 int
 main(int argc, char **argv)
 {
+	struct stat sb;
 	struct iso_args args;
-	int ch, mntflags, opts;
+	int ch, mntflags, opts, set_mask, set_dirmask;
 	char *dev, *dir, mntpath[MAXPATHLEN];
 	struct vfsconf vfc;
 	int error, verbose;
 	const char *quirk;
 	char *cs_local = NULL;
 
-	mntflags = opts = verbose = 0;
+	mntflags = opts = set_mask = set_dirmask = verbose = 0;
 	memset(&args, 0, sizeof args);
 	args.ssector = -1;
-	while ((ch = getopt(argc, argv, "begjo:rs:C:v")) != -1)
+	while ((ch = getopt(argc, argv, "begG:jm:M:o:rs:U:C:v")) != -1)
 		switch (ch) {
 		case 'b':
 			opts |= ISOFSMNT_BROKENJOLIET;
@@ -96,6 +103,18 @@ main(int argc, char **argv)
 			break;
 		case 'g':
 			opts |= ISOFSMNT_GENS;
+			break;
+		case 'G':
+			opts |= ISOFSMNT_GID;
+			args.gid = a_gid(optarg);
+			break;
+		case 'm':
+			args.fmask = a_mask(optarg);
+			set_mask = 1;
+			break;
+		case 'M':
+			args.dmask = a_mask(optarg);
+			set_dirmask = 1;
 			break;
 		case 'j':
 			opts |= ISOFSMNT_NOJOLIET;
@@ -116,6 +135,10 @@ main(int argc, char **argv)
 		case 's':
 			args.ssector = atoi(optarg);
 			break;
+		case 'U':
+			opts |= ISOFSMNT_UID;
+			args.uid = a_uid(optarg);
+			break;
 		case 'v':
 			verbose++;
 			break;
@@ -128,6 +151,14 @@ main(int argc, char **argv)
 
 	if (argc != 2)
 		usage();
+
+	if (set_mask && !set_dirmask) {
+		args.dmask = args.fmask;
+		set_dirmask = 1;
+	} else if (set_dirmask && !set_mask) {
+		args.fmask = args.dmask;
+		set_mask = 1;
+	}
 
 	dev = argv[0];
 	dir = argv[1];
@@ -167,6 +198,13 @@ main(int argc, char **argv)
 			args.ssector = 0;
 		} else if (verbose)
 			printf("using starting sector %d\n", args.ssector);
+	}
+
+	if (!set_mask) {
+		if (stat(mntpath, &sb) == -1)
+			err(EX_OSERR, "stat %s", mntpath);
+		args.fmask = args.dmask =
+			sb.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
 	}
 
 	error = getvfsbyname("cd9660", &vfc);
@@ -213,7 +251,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: mount_cd9660 [-begjrv] [-C charset] [-o options] [-s startsector] special node\n");
+	    "usage: mount_cd9660 [-begjrv] [-C charset] [-o options] [-s startsector] [-G gid] [-m mask] [-M mask] [-U uid] special node\n");
 	exit(EX_USAGE);
 }
 
@@ -257,4 +295,59 @@ get_ssector(const char *dev)
 		return -1;
 
 	return ntohl(toc_buffer[i].addr.lba);
+}
+
+static gid_t
+a_gid(const char *s)
+{
+	struct group *gr;
+	const char *gname;
+	gid_t gid;
+
+	if ((gr = getgrnam(s)) != NULL)
+		gid = gr->gr_gid;
+	else {
+		for (gname = s; *s && isdigit(*s); ++s);
+		if (!*s)
+			gid = atoi(gname);
+		else
+			errx(EX_NOUSER, "unknown group id: %s", gname);
+	}
+	return (gid);
+}
+
+static uid_t
+a_uid(const char *s)
+{
+	struct passwd *pw;
+	const char *uname;
+	uid_t uid;
+
+	if ((pw = getpwnam(s)) != NULL)
+		uid = pw->pw_uid;
+	else {
+		for (uname = s; *s && isdigit(*s); ++s);
+		if (!*s)
+			uid = atoi(uname);
+		else
+			errx(EX_NOUSER, "unknown user id: %s", uname);
+	}
+	return (uid);
+}
+
+static mode_t
+a_mask(const char *s)
+{
+	int done, rv;
+	char *ep;
+
+	done = 0;
+	rv = -1;
+	if (*s >= '0' && *s <= '7') {
+		done = 1;
+		rv = strtol(optarg, &ep, 8);
+	}
+	if (!done || rv < 0 || *ep)
+		errx(EX_USAGE, "invalid file mode: %s", s);
+	return (rv);
 }

--- a/sys/vfs/isofs/cd9660/cd9660_mount.h
+++ b/sys/vfs/isofs/cd9660/cd9660_mount.h
@@ -41,6 +41,10 @@
 struct iso_args {
 	char	*fspec;				/* block special device to mount */
 	struct	export_args export;		/* network export info */
+	uid_t	uid;				/* uid that owns ISO-9660 files */
+	gid_t	gid;				/* gid that owns ISO-9660 files */
+	mode_t	fmask;				/* file mask to be applied for files */
+	mode_t	dmask;				/* file mask to be applied for directories */
 	int	flags;				/* mounting flags, see below */
 	int	ssector;			/* starting sector, 0 for 1st session */
 	char	cs_disk[ICONV_CSNMAXLEN];	/* disk charset for Joliet cs conversion */
@@ -52,3 +56,5 @@ struct iso_args {
 #define	ISOFSMNT_NOJOLIET	0x00000008	/* disable Joliet Ext.*/
 #define	ISOFSMNT_BROKENJOLIET	0x00000010	/* allow broken Joliet disks */
 #define	ISOFSMNT_KICONV		0x00000020	/* Use libiconv to convert chars */
+#define ISOFSMNT_UID		0x00000040	/* override uid */
+#define ISOFSMNT_GID		0x00000080	/* override gid */

--- a/sys/vfs/isofs/cd9660/cd9660_vfsops.c
+++ b/sys/vfs/isofs/cd9660/cd9660_vfsops.c
@@ -447,6 +447,13 @@ iso_mountfs(struct vnode *devvp, struct mount *mp, struct iso_args *argp)
 
 	dev->si_mountpoint = mp;
 
+	if (argp->flags & ISOFSMNT_UID)
+		isomp->im_uid = argp->uid;
+	if (argp->flags & ISOFSMNT_GID)
+		isomp->im_gid = argp->gid;
+	isomp->im_fmask = argp->fmask & ACCESSPERMS;
+	isomp->im_dmask = argp->dmask & ACCESSPERMS;
+
 	/* Check the Rock Ridge Extension support */
 	if (!(argp->flags & ISOFSMNT_NORRIP)) {
 		if ((error = bread(isomp->im_devvp,
@@ -472,7 +479,8 @@ iso_mountfs(struct vnode *devvp, struct mount *mp, struct iso_args *argp)
 	}
 	isomp->im_flags = argp->flags & (ISOFSMNT_NORRIP | ISOFSMNT_GENS |
 					 ISOFSMNT_EXTATT | ISOFSMNT_NOJOLIET |
-					 ISOFSMNT_KICONV);
+					 ISOFSMNT_KICONV |
+					 ISOFSMNT_UID | ISOFSMNT_GID);
 
 	if (isomp->im_flags & ISOFSMNT_KICONV && cd9660_iconv) {
 		bcopy(argp->cs_local, cs_local, sizeof(cs_local));

--- a/sys/vfs/isofs/cd9660/cd9660_vnops.c
+++ b/sys/vfs/isofs/cd9660/cd9660_vnops.c
@@ -58,6 +58,7 @@
 #include <sys/buf2.h>
 
 #include "iso.h"
+#include "cd9660_mount.h"
 #include "cd9660_node.h"
 #include "iso_rrip.h"
 
@@ -126,10 +127,20 @@ cd9660_access(struct vop_access_args *ap)
 {
 	struct vnode *vp = ap->a_vp;
 	struct iso_node *ip = VTOI(vp);
+	mode_t file_mode;
+	uid_t uid;
+	gid_t gid;
 
 	KKASSERT(vp->v_mount->mnt_flag & MNT_RDONLY);
-	return (vop_helper_access(ap, ip->inode.iso_uid, ip->inode.iso_gid,
-				  ip->inode.iso_mode, 0));
+
+	file_mode = ip->inode.iso_mode;
+	file_mode &= (vp->v_type == VDIR) ? ip->i_mnt->im_dmask : ip->i_mnt->im_fmask;
+	uid = (ip->i_mnt->im_flags & ISOFSMNT_UID) ?
+		ip->i_mnt->im_uid : ip->inode.iso_uid;
+	gid = (ip->i_mnt->im_flags & ISOFSMNT_GID) ?
+		ip->i_mnt->im_gid : ip->inode.iso_gid;
+
+	return (vop_helper_access(ap, uid, gid, file_mode, 0));
 }
 
 /*
@@ -146,9 +157,13 @@ cd9660_getattr(struct vop_getattr_args *ap)
 	vap->va_fileid	= ip->i_number;
 
 	vap->va_mode	= ip->inode.iso_mode;
+	vap->va_mode &= (vp->v_type == VDIR) ? ip->i_mnt->im_dmask : ip->i_mnt->im_fmask;
+
 	vap->va_nlink	= ip->inode.iso_links;
-	vap->va_uid	= ip->inode.iso_uid;
-	vap->va_gid	= ip->inode.iso_gid;
+	vap->va_uid	= (ip->i_mnt->im_flags & ISOFSMNT_UID) ?
+			ip->i_mnt->im_uid : ip->inode.iso_uid;
+	vap->va_gid	= (ip->i_mnt->im_flags & ISOFSMNT_GID) ?
+			ip->i_mnt->im_gid : ip->inode.iso_gid;
 	vap->va_atime	= ip->inode.iso_atime;
 	vap->va_mtime	= ip->inode.iso_mtime;
 	vap->va_ctime	= ip->inode.iso_ctime;

--- a/sys/vfs/isofs/cd9660/iso.h
+++ b/sys/vfs/isofs/cd9660/iso.h
@@ -226,6 +226,11 @@ struct iso_mnt {
 	cdev_t im_dev;
 	struct vnode *im_devvp;
 
+	uid_t	im_uid;
+	gid_t	im_gid;
+	mode_t	im_fmask;
+	mode_t	im_dmask;
+
 	int logical_block_size;
 	int im_bshift;
 	int im_bmask;


### PR DESCRIPTION
This patch adds arbitrary mask, dirmask, uid & gid support to ISO9660 ala MSDOSFS.

Similar patches accepted in [FreeBSD](https://github.com/freebsd/freebsd-src/pull/982) & [NetBSD](https://github.com/NetBSD/src/pull/29)

How I tested it:

Compile a custom kernel with no `options CD9660` line.

```
cd /usr/src/sys/vfs/isofs/cd9660
sudo cp cd9660_mount.h /usr/include/vfs/isofs/cd9660/cd9660_mount.h
make
sudo make install
cd /usr/src/sbin/mount_cd9660
make
sudo make install
sudo vnconfig -c -v /dev/vn0 /path/to/iso.iso
sudo mount_cd9660 -m640 -M750 -Uricardo -G777 /dev/vn0 /mnt
ls -l /mnt
sudo umount /mnt
sudo vnconfig -u vn0
```

NOTE: The a_gid, a_uid & a_mask functions were taken almost verbatim from mount_msdos.c.  The only change being using `const char *` for the argument.