### PR TITLE
umount: Add -d option to detach vn device

### DIFF
--- a/sbin/umount/umount.8
+++ b/sbin/umount/umount.8
@@ -28,7 +28,7 @@
 .\"     @(#)umount.8	8.2 (Berkeley) 5/8/95
 .\" $FreeBSD: src/sbin/umount/umount.8,v 1.7.2.3 2001/12/14 15:17:57 ru Exp $
 .\"
-.Dd September 29, 2016
+.Dd March 10, 2024
 .Dt UMOUNT 8
 .Os
 .Sh NAME
@@ -36,12 +36,12 @@
 .Nd unmount filesystems
 .Sh SYNOPSIS
 .Nm
-.Op Fl fv
+.Op Fl dfv
 .Ar special \&| node
 .Nm
 .Fl a | A
 .Op Fl F Ar fstab
-.Op Fl fv
+.Op Fl dfv
 .Op Fl h Ar host
 .Op Fl t Ar type
 .Sh DESCRIPTION
@@ -71,6 +71,9 @@ are unmounted.
 .It Fl A
 All the currently mounted filesystems except
 the root are unmounted.
+.It Fl d
+If the filesystem is mounted on a memory disk (see
+.Xr vn 4) , detach it after unmount(2).
 .It Fl F Ar fstab
 Specify the
 .Pa fstab
@@ -132,7 +135,8 @@ filesystem table
 .Sh SEE ALSO
 .Xr unmount 2 ,
 .Xr fstab 5 ,
-.Xr mount 8
+.Xr mount 8 ,
+.Xr vnconfig 8
 .Sh HISTORY
 A
 .Nm


### PR DESCRIPTION
Add a `-d` option to umount to detach a vnode device.  A similar option exists in Linux's umount and FreeBSD: https://github.com/freebsd/freebsd-src/pull/972