### PR TITLE
Fix null dereference bug in fuse and re-enable it.

### DIFF
--- a/sys/vfs/Makefile
+++ b/sys/vfs/Makefile
@@ -3,7 +3,7 @@
 
 SUBDIR=	fifofs msdosfs nfs procfs \
 	hpfs ntfs smbfs isofs mfs udf \
-	nullfs hammer tmpfs autofs ext2fs # fuse
+	nullfs hammer tmpfs autofs ext2fs fuse
 
 SUBDIR+= hammer2
 

--- a/sys/vfs/fuse/fuse_vfsops.c
+++ b/sys/vfs/fuse/fuse_vfsops.c
@@ -109,7 +109,6 @@ fuse_mount(struct mount *mp, char *mntpt, caddr_t data, struct ucred *cred)
 	error = copyin(data, &args, sizeof(args));
 	if (error)
 		return error;
-	memcpy(sbp->f_mntfromname, args.from, sizeof(sbp->f_mntfromname));
 
 	memset(sbp->f_mntfromname, 0, sizeof(sbp->f_mntfromname));
 	error = copyinstr(args.from, sbp->f_mntfromname,
@@ -124,12 +123,14 @@ fuse_mount(struct mount *mp, char *mntpt, caddr_t data, struct ucred *cred)
 		return error;
 
 	memset(subtype, 0, sizeof(subtype));
-	error = copyinstr(args.subtype, subtype, sizeof(subtype), NULL);
-	if (error)
-		return error;
-	if (strlen(subtype)) {
-		strlcat(sbp->f_fstypename, ".", sizeof(sbp->f_fstypename));
-		strlcat(sbp->f_fstypename, subtype, sizeof(sbp->f_fstypename));
+	if (args.subtype != NULL) {
+		error = copyinstr(args.subtype, subtype, sizeof(subtype), NULL);
+		if (error)
+			return error;
+		if (strlen(subtype)) {
+			strlcat(sbp->f_fstypename, ".", sizeof(sbp->f_fstypename));
+			strlcat(sbp->f_fstypename, subtype, sizeof(sbp->f_fstypename));
+		}
 	}
 
 	error = nlookup_init(&nd, sbp->f_mntfromname, UIO_SYSSPACE, NLC_FOLLOW);


### PR DESCRIPTION
There was a null dereference bug in fuse if the subtype was null. subtype is supposed to be optional, as demonstrated by the code, so test it for null before copying it in from userspace.

Remove the redundant memcpy which appears to have been missed when the code was changed to memset/copyinstr.