### PR TITLE
Port of kernel bits needed for UHIDD(cuse and vkbd)

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -56,6 +56,7 @@ SUBDIR=	${SUBDIR_ORDERED} \
 	libc \
 	libc_rtld \
 	libcalendar \
+	libcuse \
 	libcompat \
 	libdevattr \
 	libdevinfo \

--- a/lib/libc/gen/Makefile.inc
+++ b/lib/libc/gen/Makefile.inc
@@ -16,7 +16,7 @@ SRCS+=  __errno_location.c _once_stub.c _pthread_stubs.c _rand48.c \
 	clock.c clock_getcpuclockid.c closedir.c confstr.c creat.c \
 	ctermid.c daemon.c devname.c dirfd.c dirname.c disklabel.c disktab.c \
 	dlfcn.c drand48.c dup3.c elf_utils.c erand48.c err.c errlst.c exec.c \
-	fdevname.c fmtcheck.c fmtmsg.c fnmatch.c fpclassify.c \
+	fdevname.c feature_present.c fmtcheck.c fmtmsg.c fnmatch.c fpclassify.c \
 	frexp.c fstab.c ftok.c fts.c ftw.c getbootfile.c getbsize.c \
 	getcap.c getcwd.c getdevpath.c getdomainname.c \
 	getentropy.c \
@@ -93,6 +93,7 @@ MLINKS+=arc4random.3 arc4random_addrandom.3 \
 MLINKS+=ctermid.3 ctermid_r.3
 MLINKS+=devname.3 devname_r.3 \
 	devname.3 fdevname.3 \
+	devname.3 feature_present.3 \
 	devname.3 fdevname_r.3
 MLINKS+=directory.3 closedir.3 \
 	directory.3 dirfd.3 \

--- a/lib/libc/gen/feature_present.3
+++ b/lib/libc/gen/feature_present.3
@@ -1,0 +1,70 @@
+.\" Copyright (c) 2008 Yahoo!, Inc.
+.\" All rights reserved.
+.\" Written by: John Baldwin <jhb@FreeBSD.org>
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\" 3. Neither the name of the author nor the names of any co-contributors
+.\"    may be used to endorse or promote products derived from this software
+.\"    without specific prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd January 8, 2008
+.Dt FEATURE_PRESENT 3
+.Os
+.Sh NAME
+.Nm feature_present
+.Nd query presence of a kernel feature
+.Sh LIBRARY
+.Lb libc
+.Sh SYNOPSIS
+.In unistd.h
+.Ft int
+.Fn feature_present "const char *feature"
+.Sh DESCRIPTION
+The
+.Fn feature_present
+function provides a method for an application to determine if a specific
+kernel feature is present in the currently running kernel.
+The
+.Fa feature
+argument specifies the name of the feature to check.
+The
+.Fn feature_present
+function will return 1 if the specified feature is present,
+otherwise it will return 0.
+If the
+.Fn feature_present
+function is not able to determine the presence of
+.Fa feature
+due to an internal error it will return 0.
+.Sh RETURN VALUES
+If
+.Fa feature
+is present then 1 is returned;
+otherwise 0 is returned.
+.Sh SEE ALSO
+.Xr sysconf 3 ,
+.Xr sysctl 3
+.Sh HISTORY
+The
+.Fn feature_present
+function first appeared in
+.Fx 8.0 .

--- a/lib/libc/gen/feature_present.c
+++ b/lib/libc/gen/feature_present.c
@@ -1,0 +1,62 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2008 Yahoo!, Inc.
+ * All rights reserved.
+ * Written by: John Baldwin <jhb@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/*
+ * Returns true if the named feature is present in the currently
+ * running kernel.  A feature's presence is indicated by an integer
+ * sysctl node called kern.feature.<feature> that is non-zero.
+ */
+int
+feature_present(const char *feature)
+{
+	char *mib;
+	size_t len;
+	int i;
+
+	if (asprintf(&mib, "kern.features.%s", feature) < 0)
+		return (0);
+	len = sizeof(i);
+	if (sysctlbyname(mib, &i, &len, NULL, 0) < 0) {
+		free(mib);
+		return (0);
+	}
+	free(mib);
+	if (len != sizeof(i))
+		return (0);
+	return (i != 0);
+}

--- a/lib/libcuse/Makefile
+++ b/lib/libcuse/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2010 Hans Petter Selasky. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+PACKAGE=lib${LIB}
+LIB=		cuse
+SHLIB_MAJOR=	1
+SHLIB_MINOR=	0
+SRCS=		cuse_lib.c
+INCS=		cuse.h
+MAN=		cuse.3
+CFLAGS+=	-D_GNU_SOURCE -I/usr/src/sys
+.if defined(HAVE_DEBUG)
+CFLAGS+=	-g
+CFLAGS+=	-DHAVE_DEBUG
+.endif
+LIBADD=	pthread
+
+MLINKS=
+MLINKS+= cuse.3 cuse_alloc_unit_number.3
+MLINKS+= cuse.3 cuse_alloc_unit_number_by_id.3
+MLINKS+= cuse.3 cuse_copy_in.3
+MLINKS+= cuse.3 cuse_copy_out.3
+MLINKS+= cuse.3 cuse_dev_create.3
+MLINKS+= cuse.3 cuse_dev_destroy.3
+MLINKS+= cuse.3 cuse_dev_get_current.3
+MLINKS+= cuse.3 cuse_dev_get_per_file_handle.3
+MLINKS+= cuse.3 cuse_dev_get_priv0.3
+MLINKS+= cuse.3 cuse_dev_get_priv1.3
+MLINKS+= cuse.3 cuse_dev_set_per_file_handle.3
+MLINKS+= cuse.3 cuse_dev_set_priv0.3
+MLINKS+= cuse.3 cuse_dev_set_priv1.3
+MLINKS+= cuse.3 cuse_free_unit_number.3
+MLINKS+= cuse.3 cuse_free_unit_number_by_id.3
+MLINKS+= cuse.3 cuse_got_peer_signal.3
+MLINKS+= cuse.3 cuse_init.3
+MLINKS+= cuse.3 cuse_poll_wakeup.3
+MLINKS+= cuse.3 cuse_set_local.3
+MLINKS+= cuse.3 cuse_get_local.3
+MLINKS+= cuse.3 cuse_uninit.3
+MLINKS+= cuse.3 cuse_vmalloc.3
+MLINKS+= cuse.3 cuse_is_vmalloc_addr.3
+MLINKS+= cuse.3 cuse_vmfree.3
+MLINKS+= cuse.3 cuse_vmoffset.3
+MLINKS+= cuse.3 cuse_wait_and_process.3
+
+.include <bsd.lib.mk>

--- a/lib/libcuse/cuse.3
+++ b/lib/libcuse/cuse.3
@@ -1,0 +1,391 @@
+.\"
+.\" Copyright (c) 2010-2022 Hans Petter Selasky
+.\"
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd July 18, 2022
+.Dt CUSE 3
+.Os
+.Sh NAME
+.Nm libcuse
+.Nd "Userland character device library"
+.Sh LIBRARY
+.Lb libcuse
+.Sh SYNOPSIS
+To load the required kernel module at boot time, place the following line in
+.Xr loader.conf 5 :
+.Bd -literal -offset indent
+cuse_load="YES"
+.Ed
+.Pp
+.In cuse.h
+.Sh DESCRIPTION
+The
+.Nm
+library contains functions to create a character device in userspace.
+The
+.Nm
+library is thread safe.
+.Sh LIBRARY INITIALISATION / DEINITIALISATION
+.Ft "int"
+.Fn "cuse_init" "void"
+This function initialises
+.Nm .
+Must be called at the beginning of the program.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+If the cuse kernel module is not loaded,
+.Dv CUSE_ERR_NOT_LOADED
+is returned.
+.Pp
+.Ft "int"
+.Fn "cuse_uninit" "void"
+Deinitialise
+.Nm .
+Can be called at the end of the application.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Sh UNIT MANAGEMENT
+.Ft "int"
+.Fn "cuse_alloc_unit_number" "int *"
+This function stores a uniq system unit number at the pointed
+integer loation.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "int"
+.Fn "cuse_alloc_unit_number_by_id" "int *" "int id"
+This function stores a unique system unit number at the pointed
+integer loation.
+The returned unit number is uniq within the given ID.
+Valid ID values are defined by the cuse include file.
+See the
+.Fn CUSE_ID_XXX
+macros for more information.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "int"
+.Fn "cuse_free_unit_number" "int"
+This function frees the given allocated system unit number.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "int"
+.Fn "cuse_free_unit_number_by_id" "int unit" "int id"
+This function frees the given allocated system unit number belonging
+to the given ID.
+If both the unit and id argument is -1, all allocated units will be freed.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Sh LIBRARY USAGE
+.Ft "void *"
+.Fn "cuse_vmalloc" "unsigned size"
+This function allocates
+.Ar size
+bytes of memory.
+Only memory allocated by this function can be memory
+mapped by
+.Xr mmap 2 .
+This function returns a valid data pointer on success or
+.Dv NULL
+on failure.
+The returned pointer is always aligned to the system page size.
+The number and size of allocations is limited by the
+.Xr mmap 2
+offset having to fit into a 32-bit variable typically for 32-bit
+applications.
+.Pp
+.Ft "int"
+.Fn "cuse_is_vmalloc_addr" "void *"
+This function returns non-zero if the passed pointer points to a valid
+and non-freed allocation, as returned by
+.Fn cuse_vmalloc .
+Else this function returns zero.
+.Pp
+.Ft "void"
+.Fn "cuse_vmfree" "void *"
+This function frees memory allocated by
+.Fn cuse_vmalloc .
+This function is NULL safe.
+.Pp
+.Ft "unsigned long"
+.Fn "cuse_vmoffset" "void *"
+This function returns the mmap offset the client must use to
+access the allocated memory.
+The passed pointer must be aligned to the system page size.
+.Pp
+.Ft "struct cuse_dev *"
+.Fn "cuse_dev_create" "const struct cuse_methods *mtod" "void *priv0" "void *priv1" "uid_t" "gid_t" "int permission" "const char *fmt" "..."
+This function creates a new character device according to the given
+parameters.
+This function returns a valid cuse_dev structure pointer
+on success or
+.Dv NULL
+on failure.
+The device name can only contain a-z,
+A-Z, 0-9, dot, / and underscore characters.
+.Pp
+.Ft "void"
+.Fn "cuse_dev_destroy" "struct cuse_dev *"
+This functions destroys a previously created character device.
+.Pp
+.Ft "void *"
+.Fn "cuse_dev_get_priv0" "struct cuse_dev *" ,
+.Ft "void *"
+.Fn "cuse_dev_get_priv1" "struct cuse_dev *" ,
+.Ft "void"
+.Fn "cuse_dev_set_priv0" "struct cuse_dev *" "void *" ,
+.Ft "void"
+.Fn "cuse_dev_set_priv1" "struct cuse_dev *" "void *"
+These functions are used to set and get the private data of the given
+cuse device.
+.Pp
+.Ft "int"
+.Fn "cuse_wait_and_process" "void"
+This function will block and do event processing.
+If parallel I/O is
+required multiple threads must be created looping on this
+function.
+This function returns 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "void *"
+.Fn "cuse_dev_get_per_file_handle" "struct cuse_dev *" ,
+.Ft "void"
+.Fn "cuse_dev_set_per_file_handle" "struct cuse_dev *" "void *"
+These functions are used to set and get the per-file-open specific handle
+and should only be used inside the cuse file operation callbacks.
+.Pp
+.Ft "void"
+.Fn "cuse_set_local" "int"
+This function instructs
+.Fn cuse_copy_out
+and
+.Fn cuse_copy_in
+that the
+user pointer is local, if the argument passed to it is non-zero.
+Else the user pointer is assumed to be at the peer application.
+This function should only be used inside the cuse file operation callbacks.
+The value is reset to zero when the given file operation returns, and
+does not affect any other file operation callbacks.
+.Pp
+.Ft "int"
+.Fn "cuse_get_local" "void"
+Returns the current local state.
+See
+.Fn cuse_set_local .
+.Pp
+.Ft "int"
+.Fn "cuse_copy_out" "const void *src" "void *peer_dst" "int len" ,
+.Ft "int"
+.Fn "cuse_copy_in" "const void *peer_src" "void *dst" "int len"
+These functions are used to transfer data between the local
+application and the peer application.
+These functions must be used
+when operating on the data pointers passed to the
+.Fn cm_read ,
+.Fn cm_write ,
+and
+.Fn cm_ioctl
+callback functions.
+These functions return 0 on success or a negative value on failure.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "int"
+.Fn "cuse_got_peer_signal" "void"
+This function is used to check if a signal has been delivered to the
+peer application and should only be used inside the cuse file
+operation callbacks.
+This function returns 0 if a signal has been
+delivered to the caller.
+Else it returns a negative value.
+See
+.Dv CUSE_ERR_XXX
+for known error codes.
+.Pp
+.Ft "struct cuse_dev *"
+.Fn "cuse_dev_get_current" "int *pcmd"
+This function is used to get the current cuse device pointer and the
+currently executing command, by
+.Dv CUSE_CMD_XXX
+value.
+The
+.Ar pcmd
+argument
+is allowed to be
+.Dv NULL .
+This function should only be used inside the
+cuse file operation callbacks.
+On success a valid cuse device pointer
+is returned.
+On failure
+.Dv NULL
+is returned.
+.Pp
+.Ft "void"
+.Fn "cuse_poll_wakeup" "void"
+This function will wake up any file pollers.
+.Sh LIBRARY LIMITATIONS
+Transfer lengths for
+.Fn read ,
+.Fn write ,
+.Fn cuse_copy_in ,
+and
+.Fn cuse_copy_out
+should not exceed what can fit into a 32-bit signed integer and is
+defined by the
+.Fn CUSE_LENGTH_MAX
+macro.
+Transfer lengths for ioctls should not exceed what is defined by the
+.Fn CUSE_BUFFER_MAX
+macro.
+.Sh LIBRARY CALLBACK METHODS
+In general fflags are defined by
+.Dv CUSE_FFLAG_XXX
+and errors are defined by
+.Dv CUSE_ERR_XXX .
+.Bd -literal -offset indent
+enum {
+  CUSE_ERR_NONE
+  CUSE_ERR_BUSY
+  CUSE_ERR_WOULDBLOCK
+  CUSE_ERR_INVALID
+  CUSE_ERR_NO_MEMORY
+  CUSE_ERR_FAULT
+  CUSE_ERR_SIGNAL
+  CUSE_ERR_OTHER
+  CUSE_ERR_NOT_LOADED
+  CUSE_ERR_NO_DEVICE
+
+  CUSE_POLL_NONE
+  CUSE_POLL_READ
+  CUSE_POLL_WRITE
+  CUSE_POLL_ERROR
+
+  CUSE_FFLAG_NONE
+  CUSE_FFLAG_READ
+  CUSE_FFLAG_WRITE
+  CUSE_FFLAG_NONBLOCK
+  CUSE_FFLAG_COMPAT32
+
+  CUSE_CMD_NONE
+  CUSE_CMD_OPEN
+  CUSE_CMD_CLOSE
+  CUSE_CMD_READ
+  CUSE_CMD_WRITE
+  CUSE_CMD_IOCTL
+  CUSE_CMD_POLL
+  CUSE_CMD_SIGNAL
+  CUSE_CMD_SYNC
+  CUSE_CMD_MAX
+};
+.Ed
+.Pp
+.Ft "int"
+.Fn "cuse_open_t" "struct cuse_dev *" "int fflags"
+This function returns a
+.Dv CUSE_ERR_XXX
+value.
+.Pp
+.Ft "int"
+.Fn "cuse_close_t" "struct cuse_dev *" "int fflags"
+This function returns a
+.Dv CUSE_ERR_XXX
+value.
+.Pp
+.Ft "int"
+.Fn "cuse_read_t" "struct cuse_dev *" "int fflags" "void *peer_ptr" "int len"
+This function returns a
+.Dv CUSE_ERR_XXX
+value in case of failure or the
+actually transferred length in case of success.
+.Fn cuse_copy_in
+and
+.Fn cuse_copy_out
+must be used to transfer data to and from the
+.Ar peer_ptr .
+.Pp
+.Ft "int"
+.Fn "cuse_write_t" "struct cuse_dev *" "int fflags" "const void *peer_ptr" "int len"
+This function returns a
+.Dv CUSE_ERR_XXX
+value in case of failure or the
+actually transferred length in case of success.
+.Fn cuse_copy_in
+and
+.Fn cuse_copy_out
+must be used to transfer data to and from the
+.Ar peer_ptr .
+.Pp
+.Ft "int"
+.Fn "cuse_ioctl_t" "struct cuse_dev *" "int fflags" "unsigned long cmd" "void *peer_data"
+This function returns a
+.Dv CUSE_ERR_XXX
+value in case of failure or zero
+in case of success.
+.Fn cuse_copy_in
+and
+.Fn cuse_copy_out
+must be used to
+transfer data to and from the
+.Ar peer_data .
+.Pp
+.Ft "int"
+.Fn "cuse_poll_t" "struct cuse_dev *" "int fflags" "int events"
+This function returns a mask of
+.Dv CUSE_POLL_XXX
+values in case of failure and success.
+The events argument is also a mask of
+.Dv CUSE_POLL_XXX
+values.
+.Bd -literal -offset indent
+struct cuse_methods {
+  cuse_open_t *cm_open;
+  cuse_close_t *cm_close;
+  cuse_read_t *cm_read;
+  cuse_write_t *cm_write;
+  cuse_ioctl_t *cm_ioctl;
+  cuse_poll_t *cm_poll;
+};
+.Ed
+.Sh HISTORY
+.Nm
+was written by Hans Petter Selasky.

--- a/lib/libcuse/cuse.h
+++ b/lib/libcuse/cuse.h
@@ -1,0 +1,96 @@
+/*-
+ * Copyright (c) 2014 Hans Petter Selasky. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _CUSE_H_
+#define	_CUSE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <vfs/cuse/cuse_defs.h>
+
+struct cuse_dev;
+
+typedef int (cuse_open_t)(struct cuse_dev *, int fflags);
+typedef int (cuse_close_t)(struct cuse_dev *, int fflags);
+typedef int (cuse_read_t)(struct cuse_dev *, int fflags, void *user_ptr, int len);
+typedef int (cuse_write_t)(struct cuse_dev *, int fflags, const void *user_ptr, int len);
+typedef int (cuse_ioctl_t)(struct cuse_dev *, int fflags, unsigned long cmd, void *user_data);
+typedef int (cuse_poll_t)(struct cuse_dev *, int fflags, int events);
+
+struct cuse_methods {
+	cuse_open_t *cm_open;
+	cuse_close_t *cm_close;
+	cuse_read_t *cm_read;
+	cuse_write_t *cm_write;
+	cuse_ioctl_t *cm_ioctl;
+	cuse_poll_t *cm_poll;
+};
+
+int	cuse_init(void);
+int	cuse_uninit(void);
+
+void   *cuse_vmalloc(unsigned);
+int	cuse_is_vmalloc_addr(void *);
+void	cuse_vmfree(void *);
+unsigned long cuse_vmoffset(void *ptr);
+
+int	cuse_alloc_unit_number_by_id(int *, int);
+int	cuse_free_unit_number_by_id(int, int);
+int	cuse_alloc_unit_number(int *);
+int	cuse_free_unit_number(int);
+
+struct cuse_dev *cuse_dev_create(const struct cuse_methods *, void *, void *, uid_t, gid_t, int, const char *,...);
+void	cuse_dev_destroy(struct cuse_dev *);
+
+void   *cuse_dev_get_priv0(struct cuse_dev *);
+void   *cuse_dev_get_priv1(struct cuse_dev *);
+
+void	cuse_dev_set_priv0(struct cuse_dev *, void *);
+void	cuse_dev_set_priv1(struct cuse_dev *, void *);
+
+void	cuse_set_local(int);
+int	cuse_get_local(void);
+
+int	cuse_wait_and_process(void);
+
+void	cuse_dev_set_per_file_handle(struct cuse_dev *, void *);
+void   *cuse_dev_get_per_file_handle(struct cuse_dev *);
+
+int	cuse_copy_out(const void *src, void *user_dst, int len);
+int	cuse_copy_in(const void *user_src, void *dst, int len);
+int	cuse_got_peer_signal(void);
+void	cuse_poll_wakeup(void);
+
+struct cuse_dev *cuse_dev_get_current(int *);
+
+extern int cuse_debug_level;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif			/* _CUSE_H_ */

--- a/lib/libcuse/cuse_lib.c
+++ b/lib/libcuse/cuse_lib.c
@@ -1,0 +1,793 @@
+/*-
+ * Copyright (c) 2010-2022 Hans Petter Selasky. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/fcntl.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+
+#include <vfs/cuse/cuse_ioctl.h>
+
+#include "cuse.h"
+
+int	cuse_debug_level;
+
+#ifdef HAVE_DEBUG
+static const char *cuse_cmd_str(int cmd);
+
+#define	DPRINTF(...) do {			\
+	if (cuse_debug_level != 0)		\
+		printf(__VA_ARGS__);		\
+} while (0)
+#else
+#define	DPRINTF(...) do { } while (0)
+#endif
+
+struct cuse_vm_allocation {
+	uint8_t *ptr;
+	uint32_t size;
+};
+
+struct cuse_dev_entered {
+	TAILQ_ENTRY(cuse_dev_entered) entry;
+	pthread_t thread;
+	void   *per_file_handle;
+	struct cuse_dev *cdev;
+	int	cmd;
+	int	is_local;
+	int	got_signal;
+};
+
+struct cuse_dev {
+	TAILQ_ENTRY(cuse_dev) entry;
+	const struct cuse_methods *mtod;
+	void   *priv0;
+	void   *priv1;
+};
+
+static int f_cuse = -1;
+
+static pthread_mutex_t m_cuse;
+static TAILQ_HEAD(, cuse_dev) h_cuse;
+static TAILQ_HEAD(, cuse_dev_entered) h_cuse_entered;
+static struct cuse_vm_allocation a_cuse[CUSE_ALLOC_UNIT_MAX];
+
+#define	CUSE_LOCK() \
+	pthread_mutex_lock(&m_cuse)
+
+#define	CUSE_UNLOCK() \
+	pthread_mutex_unlock(&m_cuse)
+
+int
+cuse_init(void)
+{
+	pthread_mutexattr_t attr;
+
+	f_cuse = open("/dev/cuse", O_RDWR);
+	if (f_cuse < 0) {
+		if (feature_present("cuse") == 0)
+			return (CUSE_ERR_NOT_LOADED);
+		else
+			return (CUSE_ERR_INVALID);
+	}
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&m_cuse, &attr);
+
+	TAILQ_INIT(&h_cuse);
+	TAILQ_INIT(&h_cuse_entered);
+
+	return (0);
+}
+
+int
+cuse_uninit(void)
+{
+	int f;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	f = f_cuse;
+	f_cuse = -1;
+
+	close(f);
+
+	pthread_mutex_destroy(&m_cuse);
+
+	memset(a_cuse, 0, sizeof(a_cuse));
+
+	return (0);
+}
+
+unsigned long
+cuse_vmoffset(void *_ptr)
+{
+	uint8_t *ptr_min;
+	uint8_t *ptr_max;
+	uint8_t *ptr = _ptr;
+	unsigned long remainder;
+	unsigned long n;
+
+	CUSE_LOCK();
+	for (n = remainder = 0; n != CUSE_ALLOC_UNIT_MAX; n++) {
+		if (a_cuse[n].ptr == NULL)
+			continue;
+
+		ptr_min = a_cuse[n].ptr;
+		ptr_max = a_cuse[n].ptr + a_cuse[n].size - 1;
+
+		if ((ptr >= ptr_min) && (ptr <= ptr_max)) {
+			remainder = (ptr - ptr_min);
+			break;
+		}
+	}
+	CUSE_UNLOCK();
+
+	return ((n << CUSE_ALLOC_UNIT_SHIFT) + remainder);
+}
+
+void   *
+cuse_vmalloc(unsigned size)
+{
+	struct cuse_alloc_info info;
+	unsigned long pgsize;
+	unsigned long x;
+	unsigned long m;
+	unsigned long n;
+	void *ptr;
+	int error;
+
+	/* some sanity checks */
+	if (f_cuse < 0 || size < 1 || size > CUSE_ALLOC_BYTES_MAX)
+		return (NULL);
+
+	memset(&info, 0, sizeof(info));
+
+	pgsize = getpagesize();
+	info.page_count = howmany(size, pgsize);
+
+	/* compute how many units the allocation needs */
+	m = howmany(size, 1 << CUSE_ALLOC_UNIT_SHIFT);
+	if (m == 0 || m > CUSE_ALLOC_UNIT_MAX)
+		return (NULL);
+
+	CUSE_LOCK();
+	for (n = 0; n <= CUSE_ALLOC_UNIT_MAX - m; ) {
+		if (a_cuse[n].size != 0) {
+			/* skip to next available unit, depending on allocation size */
+			n += howmany(a_cuse[n].size, 1 << CUSE_ALLOC_UNIT_SHIFT);
+			continue;
+		}
+		/* check if there are "m" free units ahead */
+		for (x = 1; x != m; x++) {
+			if (a_cuse[n + x].size != 0)
+				break;
+		}
+		if (x != m) {
+			/* skip to next available unit, if any */
+			n += x + 1;
+			continue;
+		}
+		/* reserve this unit by setting the size to a non-zero value */
+		a_cuse[n].size = size;
+		CUSE_UNLOCK();
+
+		info.alloc_nr = n;
+
+		error = ioctl(f_cuse, CUSE_IOCTL_ALLOC_MEMORY, &info);
+
+		if (error == 0) {
+			ptr = mmap(NULL, info.page_count * pgsize,
+			    PROT_READ | PROT_WRITE,
+			    MAP_SHARED, f_cuse, n << CUSE_ALLOC_UNIT_SHIFT);
+
+			if (ptr != MAP_FAILED) {
+				CUSE_LOCK();
+				a_cuse[n].ptr = ptr;
+				CUSE_UNLOCK();
+
+				return (ptr);		/* success */
+			}
+
+			(void) ioctl(f_cuse, CUSE_IOCTL_FREE_MEMORY, &info);
+		}
+
+		CUSE_LOCK();
+		a_cuse[n].size = 0;
+		n++;
+	}
+	CUSE_UNLOCK();
+	return (NULL);			/* failure */
+}
+
+int
+cuse_is_vmalloc_addr(void *ptr)
+{
+	int n;
+
+	if (f_cuse < 0 || ptr == NULL)
+		return (0);		/* false */
+
+	CUSE_LOCK();
+	for (n = 0; n != CUSE_ALLOC_UNIT_MAX; n++) {
+		if (a_cuse[n].ptr == ptr)
+			break;
+	}
+	CUSE_UNLOCK();
+
+	return (n != CUSE_ALLOC_UNIT_MAX);
+}
+
+void
+cuse_vmfree(void *ptr)
+{
+	struct cuse_vm_allocation temp;
+	struct cuse_alloc_info info;
+	int error;
+	int n;
+
+	if (f_cuse < 0 || ptr == NULL)
+		return;
+
+	CUSE_LOCK();
+	for (n = 0; n != CUSE_ALLOC_UNIT_MAX; n++) {
+		if (a_cuse[n].ptr != ptr)
+			continue;
+
+		temp = a_cuse[n];
+
+		CUSE_UNLOCK();
+
+		munmap(temp.ptr, temp.size);
+
+		memset(&info, 0, sizeof(info));
+
+		info.alloc_nr = n;
+
+		error = ioctl(f_cuse, CUSE_IOCTL_FREE_MEMORY, &info);
+
+		if (error != 0) {
+			/* ignore any errors */
+			DPRINTF("Freeing memory failed: %d\n", errno);
+		}
+		CUSE_LOCK();
+
+		a_cuse[n].ptr = NULL;
+		a_cuse[n].size = 0;
+
+		break;
+	}
+	CUSE_UNLOCK();
+}
+
+int
+cuse_alloc_unit_number_by_id(int *pnum, int id)
+{
+	int error;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	*pnum = (id & CUSE_ID_MASK);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_ALLOC_UNIT_BY_ID, pnum);
+	if (error)
+		return (CUSE_ERR_NO_MEMORY);
+
+	return (0);
+
+}
+
+int
+cuse_free_unit_number_by_id(int num, int id)
+{
+	int error;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	if (num != -1 || id != -1)
+		num = (id & CUSE_ID_MASK) | (num & 0xFF);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_FREE_UNIT_BY_ID, &num);
+	if (error)
+		return (CUSE_ERR_NO_MEMORY);
+
+	return (0);
+}
+
+int
+cuse_alloc_unit_number(int *pnum)
+{
+	int error;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_ALLOC_UNIT, pnum);
+	if (error)
+		return (CUSE_ERR_NO_MEMORY);
+
+	return (0);
+}
+
+int
+cuse_free_unit_number(int num)
+{
+	int error;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_FREE_UNIT, &num);
+	if (error)
+		return (CUSE_ERR_NO_MEMORY);
+
+	return (0);
+}
+
+struct cuse_dev *
+cuse_dev_create(const struct cuse_methods *mtod, void *priv0, void *priv1,
+    uid_t _uid, gid_t _gid, int _perms, const char *_fmt,...)
+{
+	struct cuse_create_dev info;
+	struct cuse_dev *cdev;
+	va_list args;
+	int error;
+
+	if (f_cuse < 0)
+		return (NULL);
+
+	cdev = malloc(sizeof(*cdev));
+	if (cdev == NULL)
+		return (NULL);
+
+	memset(cdev, 0, sizeof(*cdev));
+
+	cdev->mtod = mtod;
+	cdev->priv0 = priv0;
+	cdev->priv1 = priv1;
+
+	memset(&info, 0, sizeof(info));
+
+	info.dev = cdev;
+	info.user_id = _uid;
+	info.group_id = _gid;
+	info.permissions = _perms;
+
+	va_start(args, _fmt);
+	vsnprintf(info.devname, sizeof(info.devname), _fmt, args);
+	va_end(args);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_CREATE_DEV, &info);
+	if (error) {
+		free(cdev);
+		return (NULL);
+	}
+	CUSE_LOCK();
+	TAILQ_INSERT_TAIL(&h_cuse, cdev, entry);
+	CUSE_UNLOCK();
+
+	return (cdev);
+}
+
+
+void
+cuse_dev_destroy(struct cuse_dev *cdev)
+{
+	int error;
+
+	if (f_cuse < 0)
+		return;
+
+	CUSE_LOCK();
+	TAILQ_REMOVE(&h_cuse, cdev, entry);
+	CUSE_UNLOCK();
+
+	error = ioctl(f_cuse, CUSE_IOCTL_DESTROY_DEV, &cdev);
+	if (error)
+		return;
+
+	free(cdev);
+}
+
+void   *
+cuse_dev_get_priv0(struct cuse_dev *cdev)
+{
+	return (cdev->priv0);
+}
+
+void   *
+cuse_dev_get_priv1(struct cuse_dev *cdev)
+{
+	return (cdev->priv1);
+}
+
+void
+cuse_dev_set_priv0(struct cuse_dev *cdev, void *priv)
+{
+	cdev->priv0 = priv;
+}
+
+void
+cuse_dev_set_priv1(struct cuse_dev *cdev, void *priv)
+{
+	cdev->priv1 = priv;
+}
+
+int
+cuse_wait_and_process(void)
+{
+	pthread_t curr = pthread_self();
+	struct cuse_dev_entered *pe;
+	struct cuse_dev_entered enter;
+	struct cuse_command info;
+	struct cuse_dev *cdev;
+	int error;
+
+	if (f_cuse < 0)
+		return (CUSE_ERR_INVALID);
+
+	error = ioctl(f_cuse, CUSE_IOCTL_GET_COMMAND, &info);
+	if (error)
+		return (CUSE_ERR_OTHER);
+
+	cdev = info.dev;
+
+	CUSE_LOCK();
+	enter.thread = curr;
+	enter.per_file_handle = (void *)info.per_file_handle;
+	enter.cmd = info.command;
+	enter.is_local = 0;
+	enter.got_signal = 0;
+	enter.cdev = cdev;
+	TAILQ_INSERT_TAIL(&h_cuse_entered, &enter, entry);
+	CUSE_UNLOCK();
+
+	DPRINTF("cuse: Command = %d = %s, flags = %d, arg = 0x%08x, ptr = 0x%08x\n",
+	    (int)info.command, cuse_cmd_str(info.command), (int)info.fflags,
+	    (int)info.argument, (int)info.data_pointer);
+
+	switch (info.command) {
+	case CUSE_CMD_OPEN:
+		if (cdev->mtod->cm_open != NULL)
+			error = (cdev->mtod->cm_open) (cdev, (int)info.fflags);
+		else
+			error = 0;
+		break;
+
+	case CUSE_CMD_CLOSE:
+
+		/* wait for other threads to stop */
+
+		while (1) {
+
+			error = 0;
+
+			CUSE_LOCK();
+			TAILQ_FOREACH(pe, &h_cuse_entered, entry) {
+				if (pe->cdev != cdev)
+					continue;
+				if (pe->thread == curr)
+					continue;
+				if (pe->per_file_handle !=
+				    enter.per_file_handle)
+					continue;
+				pe->got_signal = 1;
+				pthread_kill(pe->thread, SIGHUP);
+				error = CUSE_ERR_BUSY;
+			}
+			CUSE_UNLOCK();
+
+			if (error == 0)
+				break;
+			else
+				usleep(10000);
+		}
+
+		if (cdev->mtod->cm_close != NULL)
+			error = (cdev->mtod->cm_close) (cdev, (int)info.fflags);
+		else
+			error = 0;
+		break;
+
+	case CUSE_CMD_READ:
+		if (cdev->mtod->cm_read != NULL) {
+			error = (cdev->mtod->cm_read) (cdev, (int)info.fflags,
+			    (void *)info.data_pointer, (int)info.argument);
+		} else {
+			error = CUSE_ERR_INVALID;
+		}
+		break;
+
+	case CUSE_CMD_WRITE:
+		if (cdev->mtod->cm_write != NULL) {
+			error = (cdev->mtod->cm_write) (cdev, (int)info.fflags,
+			    (void *)info.data_pointer, (int)info.argument);
+		} else {
+			error = CUSE_ERR_INVALID;
+		}
+		break;
+
+	case CUSE_CMD_IOCTL:
+		if (cdev->mtod->cm_ioctl != NULL) {
+			error = (cdev->mtod->cm_ioctl) (cdev, (int)info.fflags,
+			    (unsigned int)info.argument, (void *)info.data_pointer);
+		} else {
+			error = CUSE_ERR_INVALID;
+		}
+		break;
+
+	case CUSE_CMD_POLL:
+		if (cdev->mtod->cm_poll != NULL) {
+			error = (cdev->mtod->cm_poll) (cdev, (int)info.fflags,
+			    (int)info.argument);
+		} else {
+			error = CUSE_POLL_ERROR;
+		}
+		break;
+
+	case CUSE_CMD_SIGNAL:
+		CUSE_LOCK();
+		TAILQ_FOREACH(pe, &h_cuse_entered, entry) {
+			if (pe->cdev != cdev)
+				continue;
+			if (pe->thread == curr)
+				continue;
+			if (pe->per_file_handle !=
+			    enter.per_file_handle)
+				continue;
+			pe->got_signal = 1;
+			pthread_kill(pe->thread, SIGHUP);
+		}
+		CUSE_UNLOCK();
+		break;
+
+	default:
+		error = CUSE_ERR_INVALID;
+		break;
+	}
+
+	DPRINTF("cuse: Command error = %d for %s\n",
+	    error, cuse_cmd_str(info.command));
+
+	CUSE_LOCK();
+	TAILQ_REMOVE(&h_cuse_entered, &enter, entry);
+	CUSE_UNLOCK();
+
+	/* we ignore any sync command failures */
+	ioctl(f_cuse, CUSE_IOCTL_SYNC_COMMAND, &error);
+
+	return (0);
+}
+
+static struct cuse_dev_entered *
+cuse_dev_get_entered(void)
+{
+	struct cuse_dev_entered *pe;
+	pthread_t curr = pthread_self();
+
+	CUSE_LOCK();
+	TAILQ_FOREACH(pe, &h_cuse_entered, entry) {
+		if (pe->thread == curr)
+			break;
+	}
+	CUSE_UNLOCK();
+	return (pe);
+}
+
+void
+cuse_dev_set_per_file_handle(struct cuse_dev *cdev, void *handle)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL || pe->cdev != cdev)
+		return;
+
+	pe->per_file_handle = handle;
+	ioctl(f_cuse, CUSE_IOCTL_SET_PFH, &handle);
+}
+
+void   *
+cuse_dev_get_per_file_handle(struct cuse_dev *cdev)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL || pe->cdev != cdev)
+		return (NULL);
+
+	return (pe->per_file_handle);
+}
+
+void
+cuse_set_local(int val)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL)
+		return;
+
+	pe->is_local = val;
+}
+
+#ifdef HAVE_DEBUG
+static const char *
+cuse_cmd_str(int cmd)
+{
+	static const char *str[CUSE_CMD_MAX] = {
+		[CUSE_CMD_NONE] = "none",
+		[CUSE_CMD_OPEN] = "open",
+		[CUSE_CMD_CLOSE] = "close",
+		[CUSE_CMD_READ] = "read",
+		[CUSE_CMD_WRITE] = "write",
+		[CUSE_CMD_IOCTL] = "ioctl",
+		[CUSE_CMD_POLL] = "poll",
+		[CUSE_CMD_SIGNAL] = "signal",
+		[CUSE_CMD_SYNC] = "sync",
+	};
+
+	if ((cmd >= 0) && (cmd < CUSE_CMD_MAX) &&
+	    (str[cmd] != NULL))
+		return (str[cmd]);
+	else
+		return ("unknown");
+}
+
+#endif
+
+int
+cuse_get_local(void)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL)
+		return (0);
+
+	return (pe->is_local);
+}
+
+int
+cuse_copy_out(const void *src, void *user_dst, int len)
+{
+	struct cuse_data_chunk info;
+	struct cuse_dev_entered *pe;
+	int error;
+
+	if ((f_cuse < 0) || (len < 0))
+		return (CUSE_ERR_INVALID);
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL)
+		return (CUSE_ERR_INVALID);
+
+	DPRINTF("cuse: copy_out(%p,%p,%d), cmd = %d = %s\n",
+	    src, user_dst, len, pe->cmd, cuse_cmd_str(pe->cmd));
+
+	if (pe->is_local) {
+		memcpy(user_dst, src, len);
+	} else {
+		info.local_ptr = (uintptr_t)src;
+		info.peer_ptr = (uintptr_t)user_dst;
+		info.length = len;
+
+		error = ioctl(f_cuse, CUSE_IOCTL_WRITE_DATA, &info);
+		if (error) {
+			DPRINTF("cuse: copy_out() error = %d\n", errno);
+			return (CUSE_ERR_FAULT);
+		}
+	}
+	return (0);
+}
+
+int
+cuse_copy_in(const void *user_src, void *dst, int len)
+{
+	struct cuse_data_chunk info;
+	struct cuse_dev_entered *pe;
+	int error;
+
+	if ((f_cuse < 0) || (len < 0))
+		return (CUSE_ERR_INVALID);
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL)
+		return (CUSE_ERR_INVALID);
+
+	DPRINTF("cuse: copy_in(%p,%p,%d), cmd = %d = %s\n",
+	    user_src, dst, len, pe->cmd, cuse_cmd_str(pe->cmd));
+
+	if (pe->is_local) {
+		memcpy(dst, user_src, len);
+	} else {
+		info.local_ptr = (uintptr_t)dst;
+		info.peer_ptr = (uintptr_t)user_src;
+		info.length = len;
+
+		error = ioctl(f_cuse, CUSE_IOCTL_READ_DATA, &info);
+		if (error) {
+			DPRINTF("cuse: copy_in() error = %d\n", errno);
+			return (CUSE_ERR_FAULT);
+		}
+	}
+	return (0);
+}
+
+struct cuse_dev *
+cuse_dev_get_current(int *pcmd)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL) {
+		if (pcmd != NULL)
+			*pcmd = 0;
+		return (NULL);
+	}
+	if (pcmd != NULL)
+		*pcmd = pe->cmd;
+	return (pe->cdev);
+}
+
+int
+cuse_got_peer_signal(void)
+{
+	struct cuse_dev_entered *pe;
+
+	pe = cuse_dev_get_entered();
+	if (pe == NULL)
+		return (CUSE_ERR_INVALID);
+
+	if (pe->got_signal)
+		return (0);
+
+	return (CUSE_ERR_OTHER);
+}
+
+void
+cuse_poll_wakeup(void)
+{
+	int error = 0;
+
+	if (f_cuse < 0)
+		return;
+
+	ioctl(f_cuse, CUSE_IOCTL_SELWAKEUP, &error);
+}

--- a/share/man/man4/vkbd.4
+++ b/share/man/man4/vkbd.4
@@ -1,0 +1,153 @@
+.\" $Id: vkbd.4,v 1.4 2004/11/16 16:49:39 max Exp $
+.\"
+.Dd August 12, 2004
+.Dt VKBD 4
+.Os
+.Sh NAME
+.Nm vkbd
+.Nd the virtual AT keyboard interface
+.Sh SYNOPSIS
+.Cd "device vkbd"
+.Sh DESCRIPTION
+The
+.Nm
+interface is a software loopback mechanism that can be loosely
+described as the virtual AT keyboard analog of the
+.Xr pty 4 ,
+that is,
+.Nm
+does for virtual AT keyboards what the
+.Xr pty 4
+driver does for terminals.
+.Pp
+The
+.Nm
+driver, like the
+.Xr pty 4
+driver, provides two interfaces: a keyboard interface like the usual
+facility it is simulating (a virtual AT keyboard in the case of
+.Nm ,
+or a terminal for
+.Xr pty 4 ) ,
+and a character-special device
+.Dq control
+interface.
+.Pp
+The virtual AT keyboards are named
+.Pa vkbd0 , vkbd1 ,
+etc., one for each control device that has been opened.
+.Pp
+The
+.Nm
+interface permits opens on the special control device
+.Pa /dev/vkbdctl .
+When this device is opened,
+.Nm
+will return a handle for the lowest unused
+.Pa vkbdctl
+device (use
+.Xr devname 3
+to determine which).
+.Pp
+Each virtual AT keyboard supports the usual keyboard interface
+.Xr ioctl 2 Ns s ,
+and thus can be used with
+.Xr kbdcontrol 1
+like any other keyboard.
+The control device supports exactly the same
+.Xr ioctl 2 Ns s
+as the virtual AT keyboard device.
+Writing AT scan codes to the control device generates an input on
+the virtual AT keyboard, as if the
+(non-existent)
+hardware had just received it.
+.Pp
+The virtual AT keyboard control device, normally
+.Pa /dev/vkbdctl Ns Aq Ar N ,
+is exclusive-open
+(it cannot be opened if it is already open)
+and is restricted to the super-user.
+A
+.Xr read 2
+call will return the virtual AT keyboard status structure
+(defined in
+.In dev/vkbd/vkbd_var.h )
+if one is available;
+if not, it will either block until one is or return
+.Er EWOULDBLOCK ,
+depending on whether non-blocking I/O has been enabled.
+.Pp
+A
+.Xr write 2
+call passes AT scan codes to be
+.Dq received
+from the virtual AT keyboard.
+Each AT scan code must be passed as
+.Vt "unsigned int" .
+Although AT scan codes must be passes as
+.Vt "unsigned int" Ns s ,
+the size of the buffer passed to
+.Xr write 2
+still should be in bytes, i.e.,
+.Bd -literal -offset indent
+static unsigned int     codes[] =
+{
+/*      Make    Break */
+        0x1e,   0x9e
+};
+
+int
+main(void)
+{
+        int     fd, len;
+
+        fd = open("/dev/vkbdctl0", O_RDWR);
+        if (fd < 0)
+                err(1, "open");
+
+        /* Note sizeof(codes) - not 2! */
+        len = write(fd, codes, sizeof(codes));
+        if (len < 0)
+                err(1, "write");
+
+        close(fd);
+
+        return (0);
+}
+.Ed
+.Pp
+Write will block if there is not enough space in the input queue.
+.Pp
+The control device also supports
+.Xr select 2
+for read and write.
+.Pp
+On the last close of the control device, the virtual AT keyboard is removed.
+All queued scan codes are thrown away.
+.Sh SEE ALSO
+.Xr kbdcontrol 1 ,
+.Xr atkbdc 4 ,
+.Xr psm 4 ,
+.Xr syscons 4 ,
+.Xr vt 4
+.Sh HISTORY
+The
+.Nm
+module was implemented in
+.Fx 6.0 .
+.Sh AUTHORS
+.An Maksim Yevmenkin Aq Mt m_evmenkin@yahoo.com
+.Sh CAVEATS
+The
+.Nm
+interface is a software loopback mechanism, and, thus
+.Xr ddb 4
+will not work with it.
+Current implementation of the
+.Xr syscons 4
+driver can accept input from only one keyboard, even if it is virtual.
+Thus it is not possible to have both wired and virtual keyboard to be active
+at the same time.
+It is, however, in principal possible to obtain AT scan
+codes from the different sources and write them into the same virtual keyboard.
+The virtual keyboard state synchronization is the user's responsibility.

--- a/sys/dev/misc/Makefile
+++ b/sys/dev/misc/Makefile
@@ -1,5 +1,5 @@
 SUBDIR= amdsbwd backlight cmx cpuctl dcons ecc ichwd ipmi joy kbdmux led lpbb \
-	nmdm pcfclock snp syscons tbridge coremctl dimm aperf
+	nmdm pcfclock snp syscons tbridge coremctl dimm aperf vkbd
 
 .if ${MACHINE_ARCH} == "x86_64"
 SUBDIR+=efirt

--- a/sys/dev/misc/vkbd/Makefile
+++ b/sys/dev/misc/vkbd/Makefile
@@ -1,0 +1,11 @@
+# $Id: Makefile,v 1.1 2004/08/13 18:30:24 max Exp $
+
+KMOD=	vkbd
+SRCS=	vkbd.c opt_kbd.h
+
+.if !defined(KERNBUILDDIR)
+opt_kbd.h:
+	echo "#define KBD_INSTALL_CDEV 1" > ${.TARGET}
+.endif
+
+.include <bsd.kmod.mk>

--- a/sys/dev/misc/vkbd/vkbd.c
+++ b/sys/dev/misc/vkbd/vkbd.c
@@ -1,0 +1,1525 @@
+/*
+ * vkbd.c
+ */
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2004 Maksim Yevmenkin <m_evmenkin@yahoo.com>
+ * Copyright (c) 1999 Kazutaka YOKOTA <yokota@zodiac.mech.utsunomiya-u.ac.jp>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $Id: vkbd.c,v 1.20 2004/11/15 23:53:30 max Exp $
+ */
+
+#include "opt_kbd.h"
+
+#include <sys/param.h>
+#include <sys/conf.h>
+#include <sys/devfs.h>
+#include <sys/device.h>
+#include <sys/eventhandler.h>
+#include <sys/fcntl.h>
+#include <sys/kbio.h>
+#include <sys/kernel.h>
+#include <sys/limits.h>
+#include <sys/lock.h>
+#include <sys/malloc.h>
+#include <sys/module.h>
+#include <sys/mutex.h>
+#include <sys/poll.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/systm.h>
+#include <sys/taskqueue.h>
+#include <sys/uio.h>
+#include <dev/misc/kbd/kbdreg.h>
+#include <dev/misc/kbd/kbdtables.h>
+#include <dev/misc/vkbd/vkbd_var.h>
+
+#define DEVICE_NAME	"vkbdctl"
+#define KEYBOARD_NAME	"vkbd"
+
+MALLOC_DECLARE(M_VKBD);
+MALLOC_DEFINE(M_VKBD, KEYBOARD_NAME, "Virtual AT keyboard");
+
+DEVFS_DEFINE_CLONE_BITMAP(vkbd);
+
+/*****************************************************************************
+ *****************************************************************************
+ **                             Keyboard state
+ *****************************************************************************
+ *****************************************************************************/
+
+/*
+ * XXX
+ * For now rely on Giant mutex to protect our data structures.
+ * Just like the rest of keyboard drivers and syscons(4) do.
+ */
+
+#if 0 /* not yet */
+#define VKBD_LOCK_DECL		struct mtx ks_lock
+#define VKBD_LOCK_INIT(s)	mtx_init(&(s)->ks_lock, "vkbd_lock", NULL, MTX_DEF|MTX_RECURSE)
+#define VKBD_LOCK_DESTROY(s)	mtx_destroy(&(s)->ks_lock)
+#define VKBD_LOCK(s)		mtx_lock(&(s)->ks_lock)
+#define VKBD_UNLOCK(s)		mtx_unlock(&(s)->ks_lock)
+#define VKBD_LOCK_ASSERT(s, w)	mtx_assert(&(s)->ks_lock, w)
+#define VKBD_SLEEP(s, f, d, t) \
+	msleep(&(s)->f, &(s)->ks_lock, PCATCH | PZERO, d, t)
+#else
+#define VKBD_LOCK_DECL
+#define VKBD_LOCK_INIT(s)
+#define VKBD_LOCK_DESTROY(s)
+#define VKBD_LOCK(s)
+#define VKBD_UNLOCK(s)
+#define VKBD_LOCK_ASSERT(s, w)
+#define VKBD_SLEEP(s, f, d, t)	tsleep(&(s)->f, PCATCH | 0, d, t)
+#endif
+
+#define VKBD_KEYBOARD(d) \
+	kbd_get_keyboard(kbd_find_keyboard(KEYBOARD_NAME, dev2unit(d)))
+
+static int kbdelays[] = { 250, 500, 750, 1000 };
+static int kbrates[] = {  34,  38,  42,  46,  50,  55,  59,  63,
+                        68,  76,  84,  92, 100, 110, 118, 126,
+                       136, 152, 168, 184, 200, 220, 236, 252,
+                       272, 304, 336, 368, 400, 440, 472, 504 };
+
+/* vkbd queue */
+struct vkbd_queue
+{
+	int		q[VKBD_Q_SIZE]; /* queue */
+	int		head;		/* index of the first code */
+	int		tail;		/* index of the last code */
+	int		cc;		/* number of codes in queue */
+};
+
+typedef struct vkbd_queue	vkbd_queue_t;
+
+/* vkbd state */
+struct vkbd_state
+{
+	struct cdev	*ks_dev;	/* control device */
+
+	struct kqinfo	 ks_rsel;	/* select(2) */
+	struct kqinfo	 ks_wsel;
+
+	vkbd_queue_t	 ks_inq;	/* input key codes queue */
+	struct task	 ks_task;	/* interrupt task */
+
+	int		 ks_flags;	/* flags */
+#define OPEN		(1 << 0)	/* control device is open */
+#define COMPOSE		(1 << 1)	/* compose flag */
+#define STATUS		(1 << 2)	/* status has changed */
+#define TASK		(1 << 3)	/* interrupt task queued */
+#define READ		(1 << 4)	/* read pending */
+#define WRITE		(1 << 5)	/* write pending */
+
+	int		 ks_mode;	/* K_XLATE, K_RAW, K_CODE */
+	int		 ks_polling;	/* polling flag */
+	int		 ks_state;	/* shift/lock key state */
+	int		 ks_accents;	/* accent key index (> 0) */
+	u_int		 ks_composed_char; /* composed char code */
+	u_char		 ks_prefix;	/* AT scan code prefix */
+
+	VKBD_LOCK_DECL;
+};
+
+typedef struct vkbd_state	vkbd_state_t;
+
+/*****************************************************************************
+ *****************************************************************************
+ **                             Character device
+ *****************************************************************************
+ *****************************************************************************/
+
+static int 		vkbd_dev_clone
+		(struct dev_clone_args *ap);
+static d_open_t		vkbd_dev_open;
+static d_close_t	vkbd_dev_close;
+static d_read_t		vkbd_dev_read;
+static d_write_t	vkbd_dev_write;
+static d_ioctl_t	vkbd_dev_ioctl;
+#if 0
+static d_poll_t		vkbd_dev_poll;
+#endif
+static d_kqfilter_t	vkbd_dev_kqfilter;
+static void		vkbd_dev_intr(void *, int);
+static void		vkbd_status_changed(vkbd_state_t *);
+static int		vkbd_data_ready(vkbd_state_t *);
+static int		vkbd_data_read(vkbd_state_t *, int);
+
+static int vkbd_filter_wr_event(struct knote *, long);
+static int vkbd_filter_rd_event(struct knote *, long);
+
+static void vkbd_filter_wr_detatch(struct knote *);
+static void vkbd_filter_rd_detatch(struct knote *);
+
+static struct dev_ops	vkbd_dev_cdevsw = {
+        { "vkbd", 0, 0 },
+	.d_open =	vkbd_dev_open,
+	.d_close =	vkbd_dev_close,
+	.d_read =	vkbd_dev_read,
+	.d_write =	vkbd_dev_write,
+	.d_ioctl =	vkbd_dev_ioctl,
+	.d_kqfilter = 	vkbd_dev_kqfilter,
+#if 0
+	.d_poll =	vkbd_dev_poll,
+#endif
+};
+
+#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+static struct clonedevs	*vkbd_dev_clones = NULL;
+
+/* Clone device */
+static void
+vkbd_dev_clone(void *arg, struct ucred *cred, char *name, int namelen,
+    struct cdev **dev)
+{
+	int	unit;
+
+	if (*dev != NULL)
+		return;
+
+	if (strcmp(name, DEVICE_NAME) == 0)
+		unit = -1;
+	else if (dev_stdclone(name, NULL, DEVICE_NAME, &unit) != 1)
+		return; /* don't recognize the name */
+
+	/* find any existing device, or allocate new unit number */
+	if (clone_create(&vkbd_dev_clones, &vkbd_dev_cdevsw, &unit, dev, 0))
+		*dev = make_dev_credf(MAKEDEV_REF, &vkbd_dev_cdevsw, unit,
+			cred, UID_ROOT, GID_WHEEL, 0600, DEVICE_NAME "%d",
+			unit);
+	else
+		dev_ref(*dev);
+}
+#endif
+
+static int
+vkbd_dev_clone(struct dev_clone_args *ap)
+{
+	int unit = devfs_clone_bitmap_get(&DEVFS_CLONE_BITMAP(vkbd), 0);
+
+	ap->a_dev = make_only_dev(&vkbd_dev_cdevsw, unit, UID_ROOT, GID_WHEEL,
+				  0600, DEVICE_NAME "%d", unit);
+
+	return 0;
+}
+
+/* Open device */
+static int
+vkbd_dev_open(struct dev_open_args *ap)
+{
+        struct cdev *dev =	ap->a_head.a_dev;
+	int			 unit = dev2unit(dev), error;
+	keyboard_switch_t	*sw = NULL;
+	keyboard_t		*kbd = NULL;
+	vkbd_state_t		*state = (vkbd_state_t *) dev->si_drv1;
+
+	/* XXX FIXME: dev->si_drv1 locking */
+	if (state == NULL) {
+		if ((sw = kbd_get_switch(KEYBOARD_NAME)) == NULL)
+			return (ENXIO);
+
+		if ((error = (*sw->probe)(unit, NULL, 0)) != 0 ||
+		    (error = (*sw->init)(unit, &kbd, NULL, 0)) != 0)
+			return (error);
+
+		state = (vkbd_state_t *) kbd->kb_data;
+
+		if ((error = (*sw->enable)(kbd)) != 0) {
+			(*sw->term)(kbd);
+			return (error);
+		}
+
+#ifdef KBD_INSTALL_CDEV
+		if ((error = kbd_attach(kbd)) != 0) {
+			(*sw->disable)(kbd);
+			(*sw->term)(kbd);
+			return (error);
+		}
+#endif /* def KBD_INSTALL_CDEV */
+
+		dev->si_drv1 = kbd->kb_data;
+	}
+
+	VKBD_LOCK(state);
+
+	if (state->ks_flags & OPEN) {
+		VKBD_UNLOCK(state);
+		return (EBUSY);
+	}
+
+	state->ks_flags |= OPEN;
+	state->ks_dev = dev;
+
+	VKBD_UNLOCK(state);
+
+	return (0);
+}
+
+/* Close device */
+static int
+vkbd_dev_close(struct dev_close_args *ap)
+{
+	vkbd_state_t	*state = NULL;
+	struct cdev 	*dev = ap->a_head.a_dev;
+
+        keyboard_t      *kbd = VKBD_KEYBOARD(dev);
+
+	if (kbd == NULL)
+		return (ENXIO);
+
+	if (kbd->kb_data == NULL || kbd->kb_data != dev->si_drv1)
+		panic("%s: kbd->kb_data != dev->si_drv1\n", __func__);
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+
+	/* wait for interrupt task */
+	while (state->ks_flags & TASK)
+		VKBD_SLEEP(state, ks_task, "vkbdc", 0);
+
+	/* wakeup poll()ers */
+	KNOTE(&state->ks_rsel.ki_note, 0);
+	KNOTE(&state->ks_wsel.ki_note, 0);
+
+	state->ks_flags &= ~OPEN;
+	state->ks_dev = NULL;
+	state->ks_inq.head = state->ks_inq.tail = state->ks_inq.cc = 0;
+
+	VKBD_UNLOCK(state);
+
+	kbd_disable(kbd);
+#ifdef KBD_INSTALL_CDEV
+	kbd_detach(kbd);
+#endif /* def KBD_INSTALL_CDEV */
+	kbd_term(kbd);
+
+	/* XXX FIXME: dev->si_drv1 locking */
+	dev->si_drv1 = NULL;
+
+	return (0);
+}
+
+/* Read status */
+static int
+vkbd_dev_read(struct dev_read_args *ap)
+{
+        struct cdev     *dev = ap->a_head.a_dev;
+
+	keyboard_t	*kbd = VKBD_KEYBOARD(dev);
+	struct uio 	*uio = ap->a_uio;
+	vkbd_state_t	*state = NULL;
+	vkbd_status_t	 status;
+	int		 flag = ap->a_ioflag;
+	int		 error;
+
+	if (kbd == NULL)
+		return (ENXIO);
+
+	if (uio->uio_resid != sizeof(status))
+		return (EINVAL);
+
+	if (kbd->kb_data == NULL || kbd->kb_data != dev->si_drv1)
+		panic("%s: kbd->kb_data != dev->si_drv1\n", __func__);
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+
+	if (state->ks_flags & READ) {
+		VKBD_UNLOCK(state);
+		return (EALREADY);
+	}
+
+	state->ks_flags |= READ;
+again:
+	if (state->ks_flags & STATUS) {
+		state->ks_flags &= ~STATUS;
+
+		status.mode = state->ks_mode;
+		status.leds = KBD_LED_VAL(kbd);
+		status.lock = state->ks_state & LOCK_MASK;
+		status.delay = kbd->kb_delay1;
+		status.rate = kbd->kb_delay2;
+		bzero(status.reserved, sizeof(status.reserved));
+
+		error = uiomove((caddr_t)&status, sizeof(status), uio);
+	} else {
+		if (flag & O_NONBLOCK) {
+			error = EWOULDBLOCK;
+			goto done;
+		}
+
+		error = VKBD_SLEEP(state, ks_flags, "vkbdr", 0);
+		if (error != 0) 
+			goto done;
+
+		goto again;
+	}
+done:
+	state->ks_flags &= ~READ;
+
+	VKBD_UNLOCK(state);
+
+	return (error);
+}
+
+/* Write scancodes */
+static int
+vkbd_dev_write(struct dev_write_args *ap)
+{
+        struct cdev     *dev = ap->a_head.a_dev;
+        int             flag = ap->a_ioflag;
+        struct uio      *uio = ap->a_uio;
+	keyboard_t	*kbd = VKBD_KEYBOARD(dev);
+	vkbd_state_t	*state = NULL;
+	vkbd_queue_t	*q = NULL;
+	int		 error, avail, bytes;
+
+	if (kbd == NULL)
+		return (ENXIO);
+
+	if (uio->uio_resid <= 0)
+		return (EINVAL);
+
+	if (kbd->kb_data == NULL || kbd->kb_data != dev->si_drv1)
+		panic("%s: kbd->kb_data != dev->si_drv1\n", __func__);
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+
+	if (state->ks_flags & WRITE) {
+		VKBD_UNLOCK(state);
+		return (EALREADY);
+	}
+
+	state->ks_flags |= WRITE;
+	error = 0;
+	q = &state->ks_inq;
+
+	while (uio->uio_resid >= sizeof(q->q[0])) {
+		if (q->head == q->tail) {
+			if (q->cc == 0)
+				avail = nitems(q->q) - q->head;
+			else
+				avail = 0; /* queue must be full */
+		} else if (q->head < q->tail)
+			avail = nitems(q->q) - q->tail;
+		else
+			avail = q->head - q->tail;
+
+		if (avail == 0) {
+			if (flag & O_NONBLOCK) {
+				error = EWOULDBLOCK;
+				break;
+			}
+
+			error = VKBD_SLEEP(state, ks_inq, "vkbdw", 0);
+			if (error != 0)
+				break;
+		} else {
+			bytes = avail * sizeof(q->q[0]);
+			if (bytes > uio->uio_resid) {
+				avail = uio->uio_resid / sizeof(q->q[0]);
+				bytes = avail * sizeof(q->q[0]);
+			}
+
+			error = uiomove((caddr_t) &q->q[q->tail], bytes, uio);
+			if (error != 0)
+				break;
+
+			q->cc += avail;
+			q->tail += avail;
+			if (q->tail == nitems(q->q))
+				q->tail = 0;
+
+			/* queue interrupt task if needed */
+			if (!(state->ks_flags & TASK) &&
+			    taskqueue_enqueue(taskqueue_swi, &state->ks_task) == 0)
+				state->ks_flags |= TASK;
+		}
+	}
+
+	state->ks_flags &= ~WRITE;
+
+	VKBD_UNLOCK(state);
+
+	return (error);
+}
+
+/* Process ioctl */
+static int
+vkbd_dev_ioctl(struct dev_ioctl_args *ap)
+{
+        u_long cmd = ap->a_cmd;
+        caddr_t data = ap->a_data;
+        struct cdev *dev = ap->a_head.a_dev;
+
+	keyboard_t *kbd = VKBD_KEYBOARD(dev);
+
+	return ((kbd == NULL)? ENXIO : kbd_ioctl(kbd, cmd, data));
+}
+
+static void
+vkbd_filter_rd_detatch(struct knote *kn)
+{
+	cdev_t dev = (cdev_t) kn->kn_hook;
+	vkbd_state_t *state = (vkbd_state_t *) dev->si_drv1;
+
+	knote_remove(&state->ks_rsel.ki_note, kn);
+}
+
+static void
+vkbd_filter_wr_detatch(struct knote *kn)
+{
+	cdev_t dev = (cdev_t) kn->kn_hook;
+	vkbd_state_t *state = (vkbd_state_t *) dev->si_drv1;
+
+	knote_remove(&state->ks_wsel.ki_note, kn);
+}
+
+static int
+vkbd_filter_rd_event(struct knote *kn, long hint)
+{       
+        cdev_t dev = (cdev_t) kn->kn_hook;
+        vkbd_state_t *state = (vkbd_state_t *) dev->si_drv1;
+
+	if (state->ks_flags & STATUS)
+		return 1;
+	return 0;
+}
+
+static int
+vkbd_filter_wr_event(struct knote *kn, long hint)
+{
+	cdev_t dev = (cdev_t) kn->kn_hook;
+	vkbd_state_t *state = (vkbd_state_t *) dev->si_drv1;
+
+	vkbd_queue_t *q = NULL;
+	q = &state->ks_inq;
+
+	if (q->cc < nitems(q->q))
+		return 1;
+
+	return 0;
+}
+
+static struct filterops vkbd_rd_filterops = {
+	.f_detach = vkbd_filter_rd_detatch,
+	.f_event = vkbd_filter_rd_event,
+};
+
+static struct filterops vkbd_wr_filterops = {
+	.f_detach = vkbd_filter_wr_detatch,
+	.f_event = vkbd_filter_wr_event,
+};
+
+static int
+vkbd_dev_kqfilter(struct dev_kqfilter_args *ap)
+{
+        cdev_t dev = ap->a_head.a_dev;
+
+	vkbd_state_t *state = (vkbd_state_t *) dev->si_drv1;
+        struct knote *kn = ap->a_kn;
+	struct klist *klist;
+
+	ap->a_result = 0;
+	switch (kn->kn_filter) {
+	case EVFILT_READ:
+		kn->kn_fop = &vkbd_rd_filterops;
+		kn->kn_hook = (caddr_t)dev;
+		klist = &state->ks_rsel.ki_note;
+		break;
+	case EVFILT_WRITE:
+		kn->kn_fop = &vkbd_wr_filterops;
+		kn->kn_hook = (caddr_t)dev;
+                klist = &state->ks_wsel.ki_note;
+		break;
+	default:
+		ap->a_result = EOPNOTSUPP;
+		return (0);
+	}
+
+        knote_insert(klist, kn);
+	return (0);
+}
+
+#if 0
+/* Poll device */
+static int
+vkbd_dev_poll(struct cdev *dev, int events, struct thread *td)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) dev->si_drv1;
+	vkbd_queue_t	*q = NULL;
+	int		 revents = 0;
+
+	if (state == NULL)
+		return (ENXIO);
+
+	VKBD_LOCK(state);
+
+	q = &state->ks_inq;
+
+	if (events & (POLLIN | POLLRDNORM)) {
+		if (state->ks_flags & STATUS)
+			revents |= events & (POLLIN | POLLRDNORM);
+		else
+			selrecord(td, &state->ks_rsel);
+	}
+
+	if (events & (POLLOUT | POLLWRNORM)) {
+		if (q->cc < nitems(q->q))
+			revents |= events & (POLLOUT | POLLWRNORM);
+		else
+			selrecord(td, &state->ks_wsel);
+	}
+
+	VKBD_UNLOCK(state);
+
+	return (revents);
+}
+#endif
+
+/* Interrupt handler */
+void
+vkbd_dev_intr(void *xkbd, int pending)
+{
+	keyboard_t	*kbd = (keyboard_t *) xkbd;
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+
+	kbd_intr(kbd, NULL);
+
+	VKBD_LOCK(state);
+
+	state->ks_flags &= ~TASK;
+	wakeup(&state->ks_task);
+
+	VKBD_UNLOCK(state);
+}
+
+/* Set status change flags */
+static void
+vkbd_status_changed(vkbd_state_t *state)
+{
+	VKBD_LOCK_ASSERT(state, MA_OWNED);
+
+	if (!(state->ks_flags & STATUS)) {
+		state->ks_flags |= STATUS;
+		KNOTE(&state->ks_rsel.ki_note, 0);
+		wakeup(&state->ks_flags);
+	}
+}
+
+/* Check if we have data in the input queue */
+static int
+vkbd_data_ready(vkbd_state_t *state)
+{
+	VKBD_LOCK_ASSERT(state, MA_OWNED);
+
+	return (state->ks_inq.cc > 0);
+}
+
+/* Read one code from the input queue */
+static int
+vkbd_data_read(vkbd_state_t *state, int wait)
+{
+	vkbd_queue_t	*q = &state->ks_inq;
+	int		 c;
+
+	VKBD_LOCK_ASSERT(state, MA_OWNED);
+
+	if (q->cc == 0)
+		return (-1);
+
+	/* get first code from the queue */
+	q->cc --;
+	c = q->q[q->head ++];
+	if (q->head == nitems(q->q))
+		q->head = 0;
+
+	/* wakeup ks_inq writers/poll()ers */
+	KNOTE(&state->ks_wsel.ki_note, 0);
+	wakeup(q);
+
+	return (c);
+}
+
+/****************************************************************************
+ ****************************************************************************
+ **                              Keyboard driver
+ ****************************************************************************
+ ****************************************************************************/
+
+static int		vkbd_configure(int flags);
+static kbd_probe_t	vkbd_probe;
+static kbd_init_t	vkbd_init;
+static kbd_term_t	vkbd_term;
+static kbd_intr_t	vkbd_intr;
+static kbd_test_if_t	vkbd_test_if;
+static kbd_enable_t	vkbd_enable;
+static kbd_disable_t	vkbd_disable;
+static kbd_read_t	vkbd_read;
+static kbd_check_t	vkbd_check;
+static kbd_read_char_t	vkbd_read_char;
+static kbd_check_char_t	vkbd_check_char;
+static kbd_ioctl_t	vkbd_ioctl;
+static kbd_lock_t	vkbd_lock;
+static void		vkbd_clear_state_locked(vkbd_state_t *state);
+static kbd_clear_state_t vkbd_clear_state;
+static kbd_get_state_t	vkbd_get_state;
+static kbd_set_state_t	vkbd_set_state;
+static kbd_poll_mode_t	vkbd_poll;
+
+static keyboard_switch_t vkbdsw = {
+	.probe =	vkbd_probe,
+	.init =		vkbd_init,
+	.term =		vkbd_term,
+	.intr =		vkbd_intr,
+	.test_if =	vkbd_test_if,
+	.enable =	vkbd_enable,
+	.disable =	vkbd_disable,
+	.read =		vkbd_read,
+	.check =	vkbd_check,
+	.read_char =	vkbd_read_char,
+	.check_char =	vkbd_check_char,
+	.ioctl =	vkbd_ioctl,
+	.lock =		vkbd_lock,
+	.clear_state =	vkbd_clear_state,
+	.get_state =	vkbd_get_state,
+	.set_state =	vkbd_set_state,
+	.poll =		vkbd_poll,
+};
+
+static int	typematic(int delay, int rate);
+static int	typematic_delay(int delay);
+static int	typematic_rate(int rate);
+
+/* Return the number of found keyboards */
+static int
+vkbd_configure(int flags)
+{
+	return (1);
+}
+
+/* Detect a keyboard */
+static int
+vkbd_probe(int unit, void *arg, int flags)
+{
+	return (0);
+}
+
+/* Reset and initialize the keyboard (stolen from atkbd.c) */
+static int
+vkbd_init(int unit, keyboard_t **kbdp, void *arg, int flags)
+{
+	keyboard_t	*kbd = NULL;
+	vkbd_state_t	*state = NULL;
+	keymap_t	*keymap = NULL;
+	accentmap_t	*accmap = NULL;
+	fkeytab_t	*fkeymap = NULL;
+	int		 fkeymap_size, delay[2];
+	int		 error, needfree;
+
+	if (*kbdp == NULL) {
+		*kbdp = kbd = kmalloc(sizeof(*kbd), M_VKBD, M_NOWAIT | M_ZERO);
+		state = kmalloc(sizeof(*state), M_VKBD, M_NOWAIT | M_ZERO);
+		keymap = kmalloc(sizeof(key_map), M_VKBD, M_NOWAIT);
+		accmap = kmalloc(sizeof(accent_map), M_VKBD, M_NOWAIT);
+		fkeymap = kmalloc(sizeof(fkey_tab), M_VKBD, M_NOWAIT);
+		fkeymap_size = sizeof(fkey_tab)/sizeof(fkey_tab[0]);
+		needfree = 1;
+		if ((kbd == NULL) || (state == NULL) || (keymap == NULL) ||
+		    (accmap == NULL) || (fkeymap == NULL)) {
+			error = ENOMEM;
+			goto bad;
+		}
+
+		VKBD_LOCK_INIT(state);
+		state->ks_inq.head = state->ks_inq.tail = state->ks_inq.cc = 0;
+		TASK_INIT(&state->ks_task, 0, vkbd_dev_intr, (void *) kbd);
+	} else if (KBD_IS_INITIALIZED(*kbdp) && KBD_IS_CONFIGURED(*kbdp)) {
+		return (0);
+	} else {
+		kbd = *kbdp;
+		state = (vkbd_state_t *) kbd->kb_data;
+		keymap = kbd->kb_keymap;
+		accmap = kbd->kb_accentmap;
+		fkeymap = kbd->kb_fkeytab;
+		fkeymap_size = kbd->kb_fkeytab_size;
+		needfree = 0;
+	}
+
+	if (!KBD_IS_PROBED(kbd)) {
+		kbd_init_struct(kbd, KEYBOARD_NAME, KB_OTHER, unit, flags, 0, 0, 0);
+		bcopy(&key_map, keymap, sizeof(key_map));
+		bcopy(&accent_map, accmap, sizeof(accent_map));
+		bcopy(fkey_tab, fkeymap,
+			imin(fkeymap_size*sizeof(fkeymap[0]), sizeof(fkey_tab)));
+		kbd_set_maps(kbd, keymap, accmap, fkeymap, fkeymap_size);
+		kbd->kb_data = (void *)state;
+
+		KBD_FOUND_DEVICE(kbd);
+		KBD_PROBE_DONE(kbd);
+
+		VKBD_LOCK(state);
+		vkbd_clear_state_locked(state);
+		state->ks_mode = K_XLATE;
+		/* FIXME: set the initial value for lock keys in ks_state */
+		VKBD_UNLOCK(state);
+	}
+	if (!KBD_IS_INITIALIZED(kbd) && !(flags & KB_CONF_PROBE_ONLY)) {
+		kbd->kb_config = flags & ~KB_CONF_PROBE_ONLY;
+
+		vkbd_ioctl(kbd, KDSETLED, (caddr_t)&state->ks_state);
+		delay[0] = kbd->kb_delay1;
+		delay[1] = kbd->kb_delay2;
+		vkbd_ioctl(kbd, KDSETREPEAT, (caddr_t)delay);
+
+		KBD_INIT_DONE(kbd);
+	}
+	if (!KBD_IS_CONFIGURED(kbd)) {
+		if (kbd_register(kbd) < 0) {
+			error = ENXIO;
+			goto bad;
+		}
+		KBD_CONFIG_DONE(kbd);
+	}
+
+	return (0);
+bad:
+	if (needfree) {
+		if (state != NULL)
+			kfree(state, M_VKBD);
+		if (keymap != NULL)
+			kfree(keymap, M_VKBD);
+		if (accmap != NULL)
+			kfree(accmap, M_VKBD);
+		if (fkeymap != NULL)
+			kfree(fkeymap, M_VKBD);
+		if (kbd != NULL) {
+			kfree(kbd, M_VKBD);
+			*kbdp = NULL;	/* insure ref doesn't leak to caller */
+		}
+	}
+	return (error);
+}
+
+/* Finish using this keyboard */
+static int
+vkbd_term(keyboard_t *kbd)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+
+	kbd_unregister(kbd);
+
+	VKBD_LOCK_DESTROY(state);
+	bzero(state, sizeof(*state));
+	kfree(state, M_VKBD);
+
+	kfree(kbd->kb_keymap, M_VKBD);
+	kfree(kbd->kb_accentmap, M_VKBD);
+	kfree(kbd->kb_fkeytab, M_VKBD);
+	kfree(kbd, M_VKBD);
+
+	return (0);
+}
+
+/* Keyboard interrupt routine */
+static int
+vkbd_intr(keyboard_t *kbd, void *arg)
+{
+	int	c;
+
+	if (KBD_IS_ACTIVE(kbd) && KBD_IS_BUSY(kbd)) {
+		/* let the callback function to process the input */
+		(*kbd->kb_callback.kc_func)(kbd, KBDIO_KEYINPUT,
+					    kbd->kb_callback.kc_arg);
+	} else {
+		/* read and discard the input; no one is waiting for input */
+		do {
+			c = vkbd_read_char(kbd, FALSE);
+		} while (c != NOKEY);
+	}
+
+	return (0);
+}
+
+/* Test the interface to the device */
+static int
+vkbd_test_if(keyboard_t *kbd)
+{
+	return (0);
+}
+
+/* 
+ * Enable the access to the device; until this function is called,
+ * the client cannot read from the keyboard.
+ */
+
+static int
+vkbd_enable(keyboard_t *kbd)
+{
+	KBD_ACTIVATE(kbd);
+	return (0);
+}
+
+/* Disallow the access to the device */
+static int
+vkbd_disable(keyboard_t *kbd)
+{
+	KBD_DEACTIVATE(kbd);
+	return (0);
+}
+
+/* Read one byte from the keyboard if it's allowed */
+static int
+vkbd_read(keyboard_t *kbd, int wait)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+	int		 c;
+
+	VKBD_LOCK(state);
+	c = vkbd_data_read(state, wait);
+	VKBD_UNLOCK(state);
+
+	if (c != -1)
+		kbd->kb_count ++;
+
+	return (KBD_IS_ACTIVE(kbd)? c : -1);
+}
+
+/* Check if data is waiting */
+static int
+vkbd_check(keyboard_t *kbd)
+{
+	vkbd_state_t	*state = NULL;
+	int		 ready;
+
+	if (!KBD_IS_ACTIVE(kbd))
+		return (FALSE);
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+	ready = vkbd_data_ready(state);
+	VKBD_UNLOCK(state);
+
+	return (ready);
+}
+
+/* Read char from the keyboard (stolen from atkbd.c) */
+static u_int
+vkbd_read_char(keyboard_t *kbd, int wait)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+	u_int		 action;
+	int		 scancode, keycode;
+
+	VKBD_LOCK(state);
+
+next_code:
+
+	/* do we have a composed char to return? */
+	if (!(state->ks_flags & COMPOSE) && (state->ks_composed_char > 0)) {
+		action = state->ks_composed_char;
+		state->ks_composed_char = 0;
+		if (action > UCHAR_MAX) {
+			VKBD_UNLOCK(state);
+			return (ERRKEY);
+		}
+
+		VKBD_UNLOCK(state);
+		return (action);
+	}
+
+	/* see if there is something in the keyboard port */
+	scancode = vkbd_data_read(state, wait);
+	if (scancode == -1) {
+		VKBD_UNLOCK(state);
+		return (NOKEY);
+	}
+	/* XXX FIXME: check for -1 if wait == 1! */
+
+	kbd->kb_count ++;
+
+	/* return the byte as is for the K_RAW mode */
+	if (state->ks_mode == K_RAW) {
+		VKBD_UNLOCK(state);
+		return (scancode);
+	}
+
+	/* translate the scan code into a keycode */
+	keycode = scancode & 0x7F;
+	switch (state->ks_prefix) {
+	case 0x00:	/* normal scancode */
+		switch(scancode) {
+		case 0xB8:	/* left alt (compose key) released */
+			if (state->ks_flags & COMPOSE) {
+				state->ks_flags &= ~COMPOSE;
+				if (state->ks_composed_char > UCHAR_MAX)
+					state->ks_composed_char = 0;
+			}
+			break;
+		case 0x38:	/* left alt (compose key) pressed */
+			if (!(state->ks_flags & COMPOSE)) {
+				state->ks_flags |= COMPOSE;
+				state->ks_composed_char = 0;
+			}
+			break;
+		case 0xE0:
+		case 0xE1:
+			state->ks_prefix = scancode;
+			goto next_code;
+		}
+		break;
+	case 0xE0:      /* 0xE0 prefix */
+		state->ks_prefix = 0;
+		switch (keycode) {
+		case 0x1C:	/* right enter key */
+			keycode = 0x59;
+			break;
+		case 0x1D:	/* right ctrl key */
+			keycode = 0x5A;
+			break;
+		case 0x35:	/* keypad divide key */
+			keycode = 0x5B;
+			break;
+		case 0x37:	/* print scrn key */
+			keycode = 0x5C;
+			break;
+		case 0x38:	/* right alt key (alt gr) */
+			keycode = 0x5D;
+			break;
+		case 0x46:	/* ctrl-pause/break on AT 101 (see below) */
+			keycode = 0x68;
+			break;
+		case 0x47:	/* grey home key */
+			keycode = 0x5E;
+			break;
+		case 0x48:	/* grey up arrow key */
+			keycode = 0x5F;
+			break;
+		case 0x49:	/* grey page up key */
+			keycode = 0x60;
+			break;
+		case 0x4B:	/* grey left arrow key */
+			keycode = 0x61;
+			break;
+		case 0x4D:	/* grey right arrow key */
+			keycode = 0x62;
+			break;
+		case 0x4F:	/* grey end key */
+			keycode = 0x63;
+			break;
+		case 0x50:	/* grey down arrow key */
+			keycode = 0x64;
+			break;
+		case 0x51:	/* grey page down key */
+			keycode = 0x65;
+			break;
+		case 0x52:	/* grey insert key */
+			keycode = 0x66;
+			break;
+		case 0x53:	/* grey delete key */
+			keycode = 0x67;
+			break;
+		/* the following 3 are only used on the MS "Natural" keyboard */
+		case 0x5b:	/* left Window key */
+			keycode = 0x69;
+			break;
+		case 0x5c:	/* right Window key */
+			keycode = 0x6a;
+			break;
+		case 0x5d:	/* menu key */
+			keycode = 0x6b;
+			break;
+		case 0x5e:	/* power key */
+			keycode = 0x6d;
+			break;
+		case 0x5f:	/* sleep key */
+			keycode = 0x6e;
+			break;
+		case 0x63:	/* wake key */
+			keycode = 0x6f;
+			break;
+		default:	/* ignore everything else */
+			goto next_code;
+		}
+		break;
+	case 0xE1:	/* 0xE1 prefix */
+		/* 
+		 * The pause/break key on the 101 keyboard produces:
+		 * E1-1D-45 E1-9D-C5
+		 * Ctrl-pause/break produces:
+		 * E0-46 E0-C6 (See above.)
+		 */
+		state->ks_prefix = 0;
+		if (keycode == 0x1D)
+			state->ks_prefix = 0x1D;
+		goto next_code;
+		/* NOT REACHED */
+	case 0x1D:	/* pause / break */
+		state->ks_prefix = 0;
+		if (keycode != 0x45)
+			goto next_code;
+		keycode = 0x68;
+		break;
+	}
+
+	if (kbd->kb_type == KB_84) {
+		switch (keycode) {
+		case 0x37:	/* *(numpad)/print screen */
+			if (state->ks_flags & SHIFTS)
+				keycode = 0x5c;	/* print screen */
+			break;
+		case 0x45:	/* num lock/pause */
+			if (state->ks_flags & CTLS)
+				keycode = 0x68;	/* pause */
+			break;
+		case 0x46:	/* scroll lock/break */
+			if (state->ks_flags & CTLS)
+				keycode = 0x6c;	/* break */
+			break;
+		}
+	} else if (kbd->kb_type == KB_101) {
+		switch (keycode) {
+		case 0x5c:	/* print screen */
+			if (state->ks_flags & ALTS)
+				keycode = 0x54;	/* sysrq */
+			break;
+		case 0x68:	/* pause/break */
+			if (state->ks_flags & CTLS)
+				keycode = 0x6c;	/* break */
+			break;
+		}
+	}
+
+	/* return the key code in the K_CODE mode */
+	if (state->ks_mode == K_CODE) {
+		VKBD_UNLOCK(state);
+		return (keycode | (scancode & 0x80));
+	}
+
+	/* compose a character code */
+	if (state->ks_flags & COMPOSE) {
+		switch (keycode | (scancode & 0x80)) {
+		/* key pressed, process it */
+		case 0x47: case 0x48: case 0x49:	/* keypad 7,8,9 */
+			state->ks_composed_char *= 10;
+			state->ks_composed_char += keycode - 0x40;
+			if (state->ks_composed_char > UCHAR_MAX) {
+				VKBD_UNLOCK(state);
+				return (ERRKEY);
+			}
+			goto next_code;
+		case 0x4B: case 0x4C: case 0x4D:	/* keypad 4,5,6 */
+			state->ks_composed_char *= 10;
+			state->ks_composed_char += keycode - 0x47;
+			if (state->ks_composed_char > UCHAR_MAX) {
+				VKBD_UNLOCK(state);
+				return (ERRKEY);
+			}
+			goto next_code;
+		case 0x4F: case 0x50: case 0x51:	/* keypad 1,2,3 */
+			state->ks_composed_char *= 10;
+			state->ks_composed_char += keycode - 0x4E;
+			if (state->ks_composed_char > UCHAR_MAX) {
+				VKBD_UNLOCK(state);
+				return (ERRKEY);
+			}
+			goto next_code;
+		case 0x52:	/* keypad 0 */
+			state->ks_composed_char *= 10;
+			if (state->ks_composed_char > UCHAR_MAX) {
+				VKBD_UNLOCK(state);
+				return (ERRKEY);
+			}
+			goto next_code;
+
+		/* key released, no interest here */
+		case 0xC7: case 0xC8: case 0xC9:	/* keypad 7,8,9 */
+		case 0xCB: case 0xCC: case 0xCD:	/* keypad 4,5,6 */
+		case 0xCF: case 0xD0: case 0xD1:	/* keypad 1,2,3 */
+		case 0xD2:				/* keypad 0 */
+			goto next_code;
+
+		case 0x38:				/* left alt key */
+			break;
+
+		default:
+			if (state->ks_composed_char > 0) {
+				state->ks_flags &= ~COMPOSE;
+				state->ks_composed_char = 0;
+				VKBD_UNLOCK(state);
+				return (ERRKEY);
+			}
+			break;
+		}
+	}
+
+	/* keycode to key action */
+	action = genkbd_keyaction(kbd, keycode, scancode & 0x80,
+			&state->ks_state, &state->ks_accents);
+	if (action == NOKEY)
+		goto next_code;
+
+	VKBD_UNLOCK(state);
+
+	return (action);
+}
+
+/* Check if char is waiting */
+static int
+vkbd_check_char(keyboard_t *kbd)
+{
+	vkbd_state_t	*state = NULL;
+	int		 ready;
+
+	if (!KBD_IS_ACTIVE(kbd))
+		return (FALSE);
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+	if (!(state->ks_flags & COMPOSE) && (state->ks_composed_char > 0))
+		ready = TRUE;
+	else
+		ready = vkbd_data_ready(state);
+	VKBD_UNLOCK(state);
+
+	return (ready);
+}
+
+/* Some useful control functions (stolen from atkbd.c) */
+static int
+vkbd_ioctl(keyboard_t *kbd, u_long cmd, caddr_t arg)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+	int		 i;
+#ifdef COMPAT_FREEBSD6
+	int		 ival;
+#endif
+
+	VKBD_LOCK(state);
+
+	switch (cmd) {
+	case KDGKBMODE:		/* get keyboard mode */
+		*(int *)arg = state->ks_mode;
+		break;
+
+#ifdef COMPAT_FREEBSD6
+	case _IO('K', 7):
+		ival = IOCPARM_IVAL(arg);
+		arg = (caddr_t)&ival;
+		/* FALLTHROUGH */
+#endif
+	case KDSKBMODE:		/* set keyboard mode */
+		switch (*(int *)arg) {
+		case K_XLATE:
+			if (state->ks_mode != K_XLATE) {
+				/* make lock key state and LED state match */
+				state->ks_state &= ~LOCK_MASK;
+				state->ks_state |= KBD_LED_VAL(kbd);
+				vkbd_status_changed(state);
+			}
+			/* FALLTHROUGH */
+
+		case K_RAW:
+		case K_CODE:
+			if (state->ks_mode != *(int *)arg) {
+				vkbd_clear_state_locked(state);
+				state->ks_mode = *(int *)arg;
+				vkbd_status_changed(state);
+			}
+			break;
+
+		default:
+			VKBD_UNLOCK(state);
+			return (EINVAL);
+		}
+		break;
+
+	case KDGETLED:		/* get keyboard LED */
+		*(int *)arg = KBD_LED_VAL(kbd);
+		break;
+
+#ifdef COMPAT_FREEBSD6
+	case _IO('K', 66):
+		ival = IOCPARM_IVAL(arg);
+		arg = (caddr_t)&ival;
+		/* FALLTHROUGH */
+#endif
+	case KDSETLED:		/* set keyboard LED */
+		/* NOTE: lock key state in ks_state won't be changed */
+		if (*(int *)arg & ~LOCK_MASK) {
+			VKBD_UNLOCK(state);
+			return (EINVAL);
+		}
+
+		i = *(int *)arg;
+		/* replace CAPS LED with ALTGR LED for ALTGR keyboards */
+		if (state->ks_mode == K_XLATE &&
+		    kbd->kb_keymap->n_keys > ALTGR_OFFSET) {
+			if (i & ALKED)
+				i |= CLKED;
+			else
+				i &= ~CLKED;
+		}
+
+		KBD_LED_VAL(kbd) = *(int *)arg;
+		vkbd_status_changed(state);
+		break;
+
+	case KDGKBSTATE:	/* get lock key state */
+		*(int *)arg = state->ks_state & LOCK_MASK;
+		break;
+
+#ifdef COMPAT_FREEBSD6
+	case _IO('K', 20):
+		ival = IOCPARM_IVAL(arg);
+		arg = (caddr_t)&ival;
+		/* FALLTHROUGH */
+#endif
+	case KDSKBSTATE:	/* set lock key state */
+		if (*(int *)arg & ~LOCK_MASK) {
+			VKBD_UNLOCK(state);
+			return (EINVAL);
+		}
+		state->ks_state &= ~LOCK_MASK;
+		state->ks_state |= *(int *)arg;
+		vkbd_status_changed(state);
+		VKBD_UNLOCK(state);
+		/* set LEDs and quit */
+		return (vkbd_ioctl(kbd, KDSETLED, arg));
+
+	case KDSETREPEAT:	/* set keyboard repeat rate (new interface) */
+		i = typematic(((int *)arg)[0], ((int *)arg)[1]);
+		kbd->kb_delay1 = typematic_delay(i);
+		kbd->kb_delay2 = typematic_rate(i);
+		vkbd_status_changed(state);
+		break;
+
+#ifdef COMPAT_FREEBSD6
+	case _IO('K', 67):
+		ival = IOCPARM_IVAL(arg);
+		arg = (caddr_t)&ival;
+		/* FALLTHROUGH */
+#endif
+#if 0
+	case KDSETRAD:		/* set keyboard repeat rate (old interface) */
+		kbd->kb_delay1 = typematic_delay(*(int *)arg);
+		kbd->kb_delay2 = typematic_rate(*(int *)arg);
+		vkbd_status_changed(state);
+		break;
+#endif
+	case PIO_KEYMAP:	/* set keyboard translation table */
+	case PIO_KEYMAPENT:	/* set keyboard translation table entry */
+	case PIO_DEADKEYMAP:	/* set accent key translation table */
+#ifdef COMPAT_FREEBSD13
+	case OPIO_KEYMAP:	/* set keyboard translation table (compat) */
+	case OPIO_DEADKEYMAP:	/* set accent key translation table (compat) */
+#endif /* COMPAT_FREEBSD13 */
+		state->ks_accents = 0;
+		/* FALLTHROUGH */
+
+	default:
+		VKBD_UNLOCK(state);
+		return (genkbd_commonioctl(kbd, cmd, arg));
+	}
+
+	VKBD_UNLOCK(state);
+
+	return (0);
+}
+
+/* Lock the access to the keyboard */
+static int
+vkbd_lock(keyboard_t *kbd, int lock)
+{
+	return (1); /* XXX */
+}
+
+/* Clear the internal state of the keyboard */
+static void
+vkbd_clear_state_locked(vkbd_state_t *state)
+{
+	VKBD_LOCK_ASSERT(state, MA_OWNED);
+
+	state->ks_flags &= ~COMPOSE;
+	state->ks_polling = 0;
+	state->ks_state &= LOCK_MASK;	/* preserve locking key state */
+	state->ks_accents = 0;
+	state->ks_composed_char = 0;
+/*	state->ks_prefix = 0;		XXX */
+
+	/* flush ks_inq and wakeup writers/poll()ers */
+	state->ks_inq.head = state->ks_inq.tail = state->ks_inq.cc = 0;
+	KNOTE(&state->ks_wsel.ki_note, 0);
+	wakeup(&state->ks_inq);
+}
+
+static void
+vkbd_clear_state(keyboard_t *kbd)
+{
+	vkbd_state_t	*state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+	vkbd_clear_state_locked(state);
+	VKBD_UNLOCK(state);
+}
+
+/* Save the internal state */
+static int
+vkbd_get_state(keyboard_t *kbd, void *buf, size_t len)
+{
+	if (len == 0)
+		return (sizeof(vkbd_state_t));
+	if (len < sizeof(vkbd_state_t))
+		return (-1);
+	bcopy(kbd->kb_data, buf, sizeof(vkbd_state_t)); /* XXX locking? */
+	return (0);
+}
+
+/* Set the internal state */
+static int
+vkbd_set_state(keyboard_t *kbd, void *buf, size_t len)
+{
+	if (len < sizeof(vkbd_state_t))
+		return (ENOMEM);
+	bcopy(buf, kbd->kb_data, sizeof(vkbd_state_t)); /* XXX locking? */
+	return (0);
+}
+
+/* Set polling */
+static int
+vkbd_poll(keyboard_t *kbd, int on)
+{
+	vkbd_state_t	*state = NULL;
+
+	state = (vkbd_state_t *) kbd->kb_data;
+
+	VKBD_LOCK(state);
+
+	if (on)
+		state->ks_polling ++;
+	else
+		state->ks_polling --;
+
+	VKBD_UNLOCK(state);
+
+	return (0);
+}
+
+/*
+ * Local functions
+ */
+
+static int
+typematic_delay(int i)
+{
+	return (kbdelays[(i >> 5) & 3]);
+}
+
+static int
+typematic_rate(int i)
+{
+	return (kbrates[i & 0x1f]);
+}
+
+static int
+typematic(int delay, int rate)
+{
+	int value;
+	int i;
+
+	for (i = nitems(kbdelays) - 1; i > 0; i--) {
+		if (delay >= kbdelays[i])
+			break;
+	}
+	value = i << 5;
+	for (i = nitems(kbrates) - 1; i > 0; i--) {
+		if (rate >= kbrates[i])
+			break;
+	}
+	value |= i;
+	return (value);
+}
+
+/*****************************************************************************
+ *****************************************************************************
+ **                                    Module 
+ *****************************************************************************
+ *****************************************************************************/
+
+KEYBOARD_DRIVER(vkbd, vkbdsw, vkbd_configure);
+
+static int
+vkbd_modevent(module_t mod, int type, void *data)
+{
+#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+	static eventhandler_tag	tag;
+#endif
+	switch (type) {
+	case MOD_LOAD:
+#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+		clone_setup(&vkbd_dev_clones);
+		tag = EVENTHANDLER_REGISTER(dev_clone, vkbd_dev_clone, 0, 1000);
+		if (tag == NULL) {
+			clone_cleanup(&vkbd_dev_clones);
+			return (ENOMEM);
+		}
+#endif
+		make_autoclone_dev(&vkbd_dev_cdevsw, &DEVFS_CLONE_BITMAP(vkbd),
+				   vkbd_dev_clone, UID_ROOT, GID_WHEEL, 0600, DEVICE_NAME);
+
+		kbd_add_driver(&vkbd_kbd_driver);
+
+		break;
+
+	case MOD_UNLOAD:
+		kbd_delete_driver(&vkbd_kbd_driver);
+#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+		EVENTHANDLER_DEREGISTER(dev_clone, tag);
+		clone_cleanup(&vkbd_dev_clones);
+#endif
+
+		devfs_clone_handler_del("vkbd");
+		dev_ops_remove_all(&vkbd_dev_cdevsw);
+		devfs_clone_bitmap_uninit(&DEVFS_CLONE_BITMAP(vkbd));
+
+		break;
+
+	default:
+		return (EOPNOTSUPP);
+	}
+
+	return (0);
+}
+
+DEV_MODULE(vkbd, vkbd_modevent, NULL);

--- a/sys/dev/misc/vkbd/vkbd_var.h
+++ b/sys/dev/misc/vkbd/vkbd_var.h
@@ -1,0 +1,51 @@
+/*-
+ * vkbd_var.h
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2004 Maksim Yevmenkin <m_evmenkin@yahoo.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $Id: vkbd_var.h,v 1.4 2004/08/17 17:43:14 max Exp $
+ */
+
+#ifndef _VKBD_VAR_H_
+#define _VKBD_VAR_H_
+
+#define	VKBD_Q_SIZE	64	/* vkbd input queue size */
+
+struct vkbd_status
+{
+	int	mode;		/* keyboard mode */
+	int	leds;		/* keyboard LEDs */
+	int	lock;		/* keyboard lock key state */
+	int	delay;		/* keyboard delay */
+	int	rate;		/* keyboard rate */
+	int	reserved[3];
+};
+
+typedef struct vkbd_status	vkbd_status_t;
+typedef struct vkbd_status *	vkbd_status_p;
+
+#endif /* ndef _VKBD_VAR_H_ */

--- a/sys/vfs/Makefile
+++ b/sys/vfs/Makefile
@@ -3,7 +3,8 @@
 
 SUBDIR=	fifofs msdosfs nfs procfs \
 	hpfs ntfs smbfs isofs mfs udf \
-	nullfs hammer tmpfs autofs ext2fs fuse
+	nullfs hammer tmpfs autofs ext2fs \
+	fuse cuse
 
 SUBDIR+= hammer2
 

--- a/sys/vfs/cuse/Makefile
+++ b/sys/vfs/cuse/Makefile
@@ -1,0 +1,5 @@
+KMOD=	cuse
+
+SRCS=	cuse.c device_if.h bus_if.h
+
+.include <bsd.kmod.mk>

--- a/sys/vfs/cuse/cuse.c
+++ b/sys/vfs/cuse/cuse.c
@@ -1,0 +1,2076 @@
+/*-
+ * Copyright (c) 2010-2022 Hans Petter Selasky
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/stdint.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/kernel.h>
+#include <sys/bus.h>
+#include <sys/linker_set.h>
+#include <sys/module.h>
+#include <sys/lock.h>
+#include <sys/file.h>
+#include <sys/filedesc.h>
+#include <sys/mutex.h>
+#include <sys/condvar.h>
+#include <sys/sysctl.h>
+#include <sys/unistd.h>
+#include <sys/malloc.h>
+#include <sys/uio.h>
+#include <sys/conf.h>
+#include <sys/poll.h>
+#include <sys/queue.h>
+#include <sys/fcntl.h>
+#include <sys/devfs.h>
+#include <sys/proc.h>
+#include <sys/vnode.h>
+#include <sys/ptrace.h>
+#include <sys/sysent.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+#include <vm/vm_object.h>
+#include <vm/vm_page.h>
+#include <vm/vm_pager.h>
+
+#include <vfs/cuse/cuse_defs.h>
+#include <vfs/cuse/cuse_ioctl.h>
+
+/* set this define to zero to disable this feature */
+#define	CUSE_COPY_BUFFER_MAX \
+	CUSE_BUFFER_MAX
+
+#define	CUSE_ALLOC_PAGES_MAX \
+	(CUSE_ALLOC_BYTES_MAX / PAGE_SIZE)
+
+#if (CUSE_ALLOC_PAGES_MAX == 0)
+#error "PAGE_SIZE is too big!"
+#endif
+
+static int
+cuse_modevent(module_t mod, int type, void *data)
+{
+	switch (type) {
+	case MOD_LOAD:
+	case MOD_UNLOAD:
+		return (0);
+	default:
+		return (EOPNOTSUPP);
+	}
+}
+
+static moduledata_t cuse_mod = {
+	.name = "cuse",
+	.evhand = &cuse_modevent,
+};
+
+DECLARE_MODULE(cuse, cuse_mod, SI_SUB_DRIVERS, SI_ORDER_FIRST);
+MODULE_VERSION(cuse, 1);
+
+/*
+ * Prevent cuse4bsd.ko and cuse.ko from loading at the same time by
+ * declaring support for the cuse4bsd interface in cuse.ko:
+ */
+MODULE_VERSION(cuse4bsd, 1);
+
+#ifdef FEATURE
+FEATURE(cuse, "Userspace character devices");
+#endif
+
+struct cuse_command;
+struct cuse_server;
+struct cuse_client;
+
+struct cuse_client_command {
+	TAILQ_ENTRY(cuse_client_command) entry;
+	struct cuse_command sub;
+	struct lock sx;
+	struct cv cv;
+	struct thread *entered;
+	struct cuse_client *client;
+	struct proc *proc_curr;
+	int	proc_refs;
+	int	got_signal;
+	int	error;
+	int	command;
+};
+
+struct cuse_memory {
+	TAILQ_ENTRY(cuse_memory) entry;
+	vm_object_t object;
+	uint32_t page_count;
+	uint32_t alloc_nr;
+};
+
+struct cuse_server_dev {
+	TAILQ_ENTRY(cuse_server_dev) entry;
+	struct cuse_server *server;
+	struct cdev *kern_dev;
+	struct cuse_dev *user_dev;
+};
+
+struct cuse_server {
+	TAILQ_ENTRY(cuse_server) entry;
+	TAILQ_HEAD(, cuse_client_command) head;
+	TAILQ_HEAD(, cuse_server_dev) hdev;
+	TAILQ_HEAD(, cuse_client) hcli;
+	TAILQ_HEAD(, cuse_memory) hmem;
+	struct lock mtx;
+	struct cv cv;
+	struct kqinfo selinfo;
+	pid_t	pid;
+	int	is_closing;
+	int	refs;
+};
+
+struct cuse_client {
+	TAILQ_ENTRY(cuse_client) entry;
+	TAILQ_ENTRY(cuse_client) entry_ref;
+	struct cuse_client_command cmds[CUSE_CMD_MAX];
+	struct cuse_server *server;
+	struct cuse_server_dev *server_dev;
+
+	uintptr_t read_base;
+	uintptr_t write_base;
+	int read_length;
+	int write_length;
+	uint8_t	read_buffer[CUSE_COPY_BUFFER_MAX] __aligned(4);
+	uint8_t	write_buffer[CUSE_COPY_BUFFER_MAX] __aligned(4);
+	uint8_t	ioctl_buffer[CUSE_BUFFER_MAX] __aligned(4);
+
+	int	fflags;			/* file flags */
+	int	cflags;			/* client flags */
+#define	CUSE_CLI_IS_CLOSING 0x01
+#define	CUSE_CLI_KNOTE_NEED_READ 0x02
+#define	CUSE_CLI_KNOTE_NEED_WRITE 0x04
+#define	CUSE_CLI_KNOTE_HAS_READ 0x08
+#define	CUSE_CLI_KNOTE_HAS_WRITE 0x10
+};
+
+#define	CUSE_CLIENT_CLOSING(pcc) \
+    ((pcc)->cflags & CUSE_CLI_IS_CLOSING)
+
+static	MALLOC_DEFINE(M_CUSE, "cuse", "CUSE memory");
+
+static TAILQ_HEAD(, cuse_server) cuse_server_head;
+static struct lock cuse_global_mtx;
+static struct cdev *cuse_dev;
+static struct cuse_server *cuse_alloc_unit[CUSE_DEVICES_MAX];
+static int cuse_alloc_unit_id[CUSE_DEVICES_MAX];
+
+static void cuse_server_wakeup_all_client_locked(struct cuse_server *pcs);
+static void cuse_client_kqfilter_read_detach(struct knote *kn);
+static void cuse_client_kqfilter_write_detach(struct knote *kn);
+static int cuse_client_kqfilter_read_event(struct knote *kn, long hint);
+static int cuse_client_kqfilter_write_event(struct knote *kn, long hint);
+
+static struct filterops cuse_client_kqfilter_read_ops = {
+	.f_detach = cuse_client_kqfilter_read_detach,
+	.f_event = cuse_client_kqfilter_read_event,
+};
+
+static struct filterops cuse_client_kqfilter_write_ops = {
+	.f_detach = cuse_client_kqfilter_write_detach,
+	.f_event = cuse_client_kqfilter_write_event,
+};
+
+static d_open_t cuse_client_open;
+static d_close_t cuse_client_close;
+static d_ioctl_t cuse_client_ioctl;
+static d_read_t cuse_client_read;
+static d_write_t cuse_client_write;
+// static int cuse_client_poll;
+static d_mmap_single_t cuse_client_mmap_single;
+static d_kqfilter_t cuse_client_kqfilter;
+
+static struct dev_ops cuse_client_devsw = {
+        { "cuse_server", 0, 0 },
+	.d_open = cuse_client_open,
+	.d_close = cuse_client_close,
+	.d_ioctl = cuse_client_ioctl,
+	.d_read = cuse_client_read,
+	.d_write = cuse_client_write,
+	.d_mmap_single = cuse_client_mmap_single,
+	.d_kqfilter = cuse_client_kqfilter,
+};
+
+static d_open_t cuse_server_open;
+static d_close_t cuse_server_close;
+static d_ioctl_t cuse_server_ioctl;
+static d_read_t cuse_server_read;
+static d_write_t cuse_server_write;
+#if 0
+static d_poll_t cuse_server_poll;
+#endif
+static d_mmap_single_t cuse_server_mmap_single;
+
+static struct dev_ops cuse_server_devsw = {
+	{ "cuse_server", 0, 0 },
+	.d_open = cuse_server_open,
+	.d_close = cuse_server_close,
+	.d_ioctl = cuse_server_ioctl,
+	.d_read = cuse_server_read,
+	.d_write = cuse_server_write,
+#if 0
+	.d_poll = cuse_server_poll,
+#endif
+	.d_mmap_single = cuse_server_mmap_single,
+};
+
+static void cuse_client_is_closing(struct cuse_client *);
+static int cuse_free_unit_by_id_locked(struct cuse_server *, int);
+
+static void
+cuse_global_lock(void)
+{
+	lockmgr(&cuse_global_mtx, LK_EXCLUSIVE);
+}
+
+static void
+cuse_global_unlock(void)
+{
+	lockmgr(&cuse_global_mtx, LK_RELEASE);
+}
+
+static void
+cuse_server_lock(struct cuse_server *pcs)
+{
+	lockmgr(&pcs->mtx, LK_EXCLUSIVE);
+}
+
+static void
+cuse_server_unlock(struct cuse_server *pcs)
+{
+	lockmgr(&pcs->mtx, LK_RELEASE);
+}
+
+static bool
+cuse_server_is_locked(struct cuse_server *pcs)
+{
+	return (lockstatus((&pcs->mtx), curthread));
+}
+
+static void
+cuse_cmd_lock(struct cuse_client_command *pccmd)
+{
+	lockmgr(&pccmd->sx, LK_EXCLUSIVE);
+}
+
+static void
+cuse_cmd_unlock(struct cuse_client_command *pccmd)
+{
+	lockmgr(&pccmd->sx, LK_RELEASE);
+}
+
+static void
+cuse_kern_init(void *arg)
+{
+	TAILQ_INIT(&cuse_server_head);
+
+	lockinit(&cuse_global_mtx, "cuse-global-lock", 0, LK_CANRECURSE);
+
+	cuse_dev = make_dev(&cuse_server_devsw, 0,
+	    UID_ROOT, GID_OPERATOR, 0600, "cuse");
+
+	kprintf("Cuse v%d.%d.%d @ /dev/cuse\n",
+	    (CUSE_VERSION >> 16) & 0xFF, (CUSE_VERSION >> 8) & 0xFF,
+	    (CUSE_VERSION >> 0) & 0xFF);
+}
+SYSINIT(cuse_kern_init, SI_SUB_VFS, SI_ORDER_ANY, cuse_kern_init, NULL);
+
+static void
+cuse_kern_uninit(void *arg)
+{
+	void *ptr;
+
+	while (1) {
+		kprintf("Cuse: Please exit all /dev/cuse instances "
+		    "and processes which have used this device.\n");
+
+		tsleep(cuse_kern_uninit, 0, "DRAIN", 2 * hz);
+
+		cuse_global_lock();
+		ptr = TAILQ_FIRST(&cuse_server_head);
+		cuse_global_unlock();
+
+		if (ptr == NULL)
+			break;
+	}
+
+	if (cuse_dev != NULL)
+		destroy_dev(cuse_dev);
+
+	lockuninit(&cuse_global_mtx);
+}
+SYSUNINIT(cuse_kern_uninit, SI_SUB_VFS, SI_ORDER_ANY, cuse_kern_uninit, NULL);
+
+static int
+cuse_server_get(struct file *fp, struct cuse_server **ppcs)
+{
+	struct cuse_server *pcs;
+	int error;
+
+	error = devfs_get_cdevpriv(fp, (void **)&pcs);
+	if (error != 0) {
+		*ppcs = NULL;
+		return (error);
+	}
+	if (pcs->is_closing) {
+		*ppcs = NULL;
+		return (EINVAL);
+	}
+	*ppcs = pcs;
+	return (0);
+}
+
+static void
+cuse_server_is_closing(struct cuse_server *pcs)
+{
+	struct cuse_client *pcc;
+
+	if (pcs->is_closing)
+		return;
+
+	pcs->is_closing = 1;
+
+	TAILQ_FOREACH(pcc, &pcs->hcli, entry) {
+		cuse_client_is_closing(pcc);
+	}
+}
+
+static struct cuse_client_command *
+cuse_server_find_command(struct cuse_server *pcs, struct thread *td)
+{
+	struct cuse_client *pcc;
+	int n;
+
+	if (pcs->is_closing)
+		goto done;
+
+	TAILQ_FOREACH(pcc, &pcs->hcli, entry) {
+		if (CUSE_CLIENT_CLOSING(pcc))
+			continue;
+		for (n = 0; n != CUSE_CMD_MAX; n++) {
+			if (pcc->cmds[n].entered == td)
+				return (&pcc->cmds[n]);
+		}
+	}
+done:
+	return (NULL);
+}
+
+static void
+cuse_str_filter(char *ptr)
+{
+	int c;
+
+	while (((c = *ptr) != 0)) {
+		if ((c >= 'a') && (c <= 'z')) {
+			ptr++;
+			continue;
+		}
+		if ((c >= 'A') && (c <= 'Z')) {
+			ptr++;
+			continue;
+		}
+		if ((c >= '0') && (c <= '9')) {
+			ptr++;
+			continue;
+		}
+		if ((c == '.') || (c == '_') || (c == '/')) {
+			ptr++;
+			continue;
+		}
+		*ptr = '_';
+
+		ptr++;
+	}
+}
+
+static int
+cuse_convert_error(int error)
+{
+	;				/* indent fix */
+	switch (error) {
+	case CUSE_ERR_NONE:
+		return (0);
+	case CUSE_ERR_BUSY:
+		return (EBUSY);
+	case CUSE_ERR_WOULDBLOCK:
+		return (EWOULDBLOCK);
+	case CUSE_ERR_INVALID:
+		return (EINVAL);
+	case CUSE_ERR_NO_MEMORY:
+		return (ENOMEM);
+	case CUSE_ERR_FAULT:
+		return (EFAULT);
+	case CUSE_ERR_SIGNAL:
+		return (EINTR);
+	case CUSE_ERR_NO_DEVICE:
+		return (ENODEV);
+	default:
+		return (ENXIO);
+	}
+}
+
+static void
+cuse_vm_memory_free(struct cuse_memory *mem)
+{
+	/* last user is gone - free */
+	vm_object_deallocate(mem->object);
+
+	/* free CUSE memory */
+	kfree(mem, M_CUSE);
+}
+
+static int
+cuse_server_alloc_memory(struct cuse_server *pcs, uint32_t alloc_nr,
+    uint32_t page_count)
+{
+	struct cuse_memory *temp;
+	struct cuse_memory *mem;
+	vm_object_t object;
+	int error;
+
+	mem = kmalloc(sizeof(*mem), M_CUSE, M_WAITOK | M_ZERO);
+
+	object = swap_pager_alloc(NULL, PAGE_SIZE * page_count,
+	    VM_PROT_DEFAULT, 0);
+	if (object == NULL) {
+		error = ENOMEM;
+		goto error_0;
+	}
+
+	cuse_server_lock(pcs);
+	/* check if allocation number already exists */
+	TAILQ_FOREACH(temp, &pcs->hmem, entry) {
+		if (temp->alloc_nr == alloc_nr)
+			break;
+	}
+	if (temp != NULL) {
+		cuse_server_unlock(pcs);
+		error = EBUSY;
+		goto error_1;
+	}
+	mem->object = object;
+	mem->page_count = page_count;
+	mem->alloc_nr = alloc_nr;
+	TAILQ_INSERT_TAIL(&pcs->hmem, mem, entry);
+	cuse_server_unlock(pcs);
+
+	return (0);
+
+error_1:
+	vm_object_deallocate(object);
+error_0:
+	kfree(mem, M_CUSE);
+	return (error);
+}
+
+static int
+cuse_server_free_memory(struct cuse_server *pcs, uint32_t alloc_nr)
+{
+	struct cuse_memory *mem;
+
+	cuse_server_lock(pcs);
+	TAILQ_FOREACH(mem, &pcs->hmem, entry) {
+		if (mem->alloc_nr == alloc_nr)
+			break;
+	}
+	if (mem == NULL) {
+		cuse_server_unlock(pcs);
+		return (EINVAL);
+	}
+	TAILQ_REMOVE(&pcs->hmem, mem, entry);
+	cuse_server_unlock(pcs);
+
+	cuse_vm_memory_free(mem);
+
+	return (0);
+}
+
+static int
+cuse_client_get(struct file *fp, struct cuse_client **ppcc)
+{
+	struct cuse_client *pcc;
+	int error;
+
+	/* try to get private data */
+	error = devfs_get_cdevpriv(fp, (void **)&pcc);
+	if (error != 0) {
+		*ppcc = NULL;
+		return (error);
+	}
+	if (CUSE_CLIENT_CLOSING(pcc) || pcc->server->is_closing) {
+		*ppcc = NULL;
+		return (EINVAL);
+	}
+	*ppcc = pcc;
+	return (0);
+}
+
+static void
+cuse_client_is_closing(struct cuse_client *pcc)
+{
+	struct cuse_client_command *pccmd;
+	uint32_t n;
+
+	if (CUSE_CLIENT_CLOSING(pcc))
+		return;
+
+	pcc->cflags |= CUSE_CLI_IS_CLOSING;
+	pcc->server_dev = NULL;
+
+	for (n = 0; n != CUSE_CMD_MAX; n++) {
+		pccmd = &pcc->cmds[n];
+
+		if (pccmd->entry.tqe_prev != NULL) {
+			TAILQ_REMOVE(&pcc->server->head, pccmd, entry);
+			pccmd->entry.tqe_prev = NULL;
+		}
+		cv_broadcast(&pccmd->cv);
+	}
+}
+
+static void
+cuse_client_send_command_locked(struct cuse_client_command *pccmd,
+    uintptr_t data_ptr, unsigned long arg, int fflags, int ioflag)
+{
+	unsigned long cuse_fflags = 0;
+	struct cuse_server *pcs;
+
+	if (fflags & FREAD)
+		cuse_fflags |= CUSE_FFLAG_READ;
+
+	if (fflags & FWRITE)
+		cuse_fflags |= CUSE_FFLAG_WRITE;
+
+	if (ioflag & IO_NDELAY)
+		cuse_fflags |= CUSE_FFLAG_NONBLOCK;
+#ifndef __LP64__
+	HEY! IF WE HAVE 32 BIT BINARY COMPAT WE NEED TO CHECK FOR IT
+	if (SV_CURPROC_FLAG(SV_ILP32))
+		cuse_fflags |= CUSE_FFLAG_COMPAT32;
+#endif
+	pccmd->sub.fflags = cuse_fflags;
+	pccmd->sub.data_pointer = data_ptr;
+	pccmd->sub.argument = arg;
+
+	pcs = pccmd->client->server;
+
+	if ((pccmd->entry.tqe_prev == NULL) &&
+	    (CUSE_CLIENT_CLOSING(pccmd->client) == 0) &&
+	    (pcs->is_closing == 0)) {
+		TAILQ_INSERT_TAIL(&pcs->head, pccmd, entry);
+		cv_signal(&pcs->cv);
+	}
+}
+
+static void
+cuse_client_got_signal(struct cuse_client_command *pccmd)
+{
+	struct cuse_server *pcs;
+
+	pccmd->got_signal = 1;
+
+	pccmd = &pccmd->client->cmds[CUSE_CMD_SIGNAL];
+
+	pcs = pccmd->client->server;
+
+	if ((pccmd->entry.tqe_prev == NULL) &&
+	    (CUSE_CLIENT_CLOSING(pccmd->client) == 0) &&
+	    (pcs->is_closing == 0)) {
+		TAILQ_INSERT_TAIL(&pcs->head, pccmd, entry);
+		cv_signal(&pcs->cv);
+	}
+}
+
+static int
+cuse_client_receive_command_locked(struct cuse_client_command *pccmd,
+    uint8_t *arg_ptr, uint32_t arg_len)
+{
+	struct cuse_server *pcs;
+	int error;
+
+	pcs = pccmd->client->server;
+	error = 0;
+
+	pccmd->proc_curr = curthread->td_proc;
+
+	if (CUSE_CLIENT_CLOSING(pccmd->client) || pcs->is_closing) {
+		error = CUSE_ERR_OTHER;
+		goto done;
+	}
+	while (pccmd->command == CUSE_CMD_NONE) {
+		if (error != 0) {
+			cv_wait(&pccmd->cv, &pcs->mtx);
+		} else {
+			error = cv_wait_sig(&pccmd->cv, &pcs->mtx);
+
+			if (error != 0)
+				cuse_client_got_signal(pccmd);
+		}
+		if (CUSE_CLIENT_CLOSING(pccmd->client) || pcs->is_closing) {
+			error = CUSE_ERR_OTHER;
+			goto done;
+		}
+	}
+
+	error = pccmd->error;
+	pccmd->command = CUSE_CMD_NONE;
+	cv_signal(&pccmd->cv);
+
+done:
+
+	/* wait until all process references are gone */
+
+	pccmd->proc_curr = NULL;
+
+	while (pccmd->proc_refs != 0)
+		cv_wait(&pccmd->cv, &pcs->mtx);
+
+	return (error);
+}
+
+/*------------------------------------------------------------------------*
+ *	CUSE SERVER PART
+ *------------------------------------------------------------------------*/
+
+static void
+cuse_server_free_dev(struct cuse_server_dev *pcsd)
+{
+	struct cuse_server *pcs;
+	struct cuse_client *pcc;
+
+	/* get server pointer */
+	pcs = pcsd->server;
+
+	/* prevent creation of more devices */
+	cuse_server_lock(pcs);
+	if (pcsd->kern_dev != NULL)
+		pcsd->kern_dev->si_drv1 = NULL;
+
+	TAILQ_FOREACH(pcc, &pcs->hcli, entry) {
+		if (pcc->server_dev == pcsd)
+			cuse_client_is_closing(pcc);
+	}
+	cuse_server_unlock(pcs);
+
+	/* destroy device, if any */
+	if (pcsd->kern_dev != NULL) {
+		/* destroy device synchronously */
+		destroy_dev(pcsd->kern_dev);
+	}
+	kfree(pcsd, M_CUSE);
+}
+
+static void
+cuse_server_unref(struct cuse_server *pcs)
+{
+	struct cuse_server_dev *pcsd;
+	struct cuse_memory *mem;
+
+	cuse_server_lock(pcs);
+	if (--(pcs->refs) != 0) {
+		cuse_server_unlock(pcs);
+		return;
+	}
+	cuse_server_is_closing(pcs);
+	/* final client wakeup, if any */
+	cuse_server_wakeup_all_client_locked(pcs);
+
+	cuse_global_lock();
+	TAILQ_REMOVE(&cuse_server_head, pcs, entry);
+	cuse_global_unlock();
+
+	while ((pcsd = TAILQ_FIRST(&pcs->hdev)) != NULL) {
+		TAILQ_REMOVE(&pcs->hdev, pcsd, entry);
+		cuse_server_unlock(pcs);
+		cuse_server_free_dev(pcsd);
+		cuse_server_lock(pcs);
+	}
+
+	cuse_free_unit_by_id_locked(pcs, -1);
+
+	while ((mem = TAILQ_FIRST(&pcs->hmem)) != NULL) {
+		TAILQ_REMOVE(&pcs->hmem, mem, entry);
+		cuse_server_unlock(pcs);
+		cuse_vm_memory_free(mem);
+		cuse_server_lock(pcs);
+	}
+#if 0
+	knlist_clear(&pcs->selinfo.ki_note, 1);
+	knlist_destroy(&pcs->selinfo.ki_note);
+#endif
+	cuse_server_unlock(pcs);
+#if 0
+	seldrain(&pcs->selinfo);
+#endif
+	cv_destroy(&pcs->cv);
+
+	lockuninit(&pcs->mtx);
+
+	kfree(pcs, M_CUSE);
+}
+
+static int
+cuse_server_do_close(struct cuse_server *pcs)
+{
+	int retval;
+
+	cuse_server_lock(pcs);
+	cuse_server_is_closing(pcs);
+	/* final client wakeup, if any */
+	cuse_server_wakeup_all_client_locked(pcs);
+#if 0
+	knlist_clear(&pcs->selinfo.ki_note, 1);
+#endif
+	retval = pcs->refs;
+	cuse_server_unlock(pcs);
+
+	return (retval);
+}
+
+static void
+cuse_server_free(void *arg)
+{
+	struct cuse_server *pcs = arg;
+
+	/*
+	 * The final server unref should be done by the server thread
+	 * to prevent deadlock in the client cdevpriv destructor,
+	 * which cannot destroy itself.
+	 */
+	while (cuse_server_do_close(pcs) != 1)
+		tsleep(cuse_server_free, 0, "W", hz);
+
+	/* drop final refcount */
+	cuse_server_unref(pcs);
+}
+
+static int
+cuse_server_open(struct dev_open_args *ap)
+{
+	struct cuse_server *pcs;
+
+	pcs = kmalloc(sizeof(*pcs), M_CUSE, M_WAITOK | M_ZERO);
+
+	if (devfs_set_cdevpriv(*ap->a_fpp, pcs, &cuse_server_free)) {
+		kprintf("Cuse: Cannot set cdevpriv.\n");
+		kfree(pcs, M_CUSE);
+		return (ENOMEM);
+	}
+	/* store current process ID */
+	pcs->pid = curproc->p_pid;
+
+	TAILQ_INIT(&pcs->head);
+	TAILQ_INIT(&pcs->hdev);
+	TAILQ_INIT(&pcs->hcli);
+	TAILQ_INIT(&pcs->hmem);
+
+	cv_init(&pcs->cv, "cuse-server-cv");
+
+	lockinit(&cuse_global_mtx, "cuse-global-lock", 0, LK_CANRECURSE);
+
+	// knlist_init_mtx(&pcs->selinfo.ki_note, &pcs->mtx);
+	lockinit(&pcs->mtx, "cuse-mtx", 0, LK_CANRECURSE);
+
+	cuse_global_lock();
+	pcs->refs++;
+	TAILQ_INSERT_TAIL(&cuse_server_head, pcs, entry);
+	cuse_global_unlock();
+
+	return (0);
+}
+
+static int
+cuse_server_close(struct dev_close_args *ap)
+{
+	struct cuse_server *pcs;
+
+	if (cuse_server_get(ap->a_fp, &pcs) == 0)
+		cuse_server_do_close(pcs);
+
+	return (0);
+}
+
+static int
+cuse_server_read(struct dev_read_args *ap)
+{
+	return (ENXIO);
+}
+
+static int
+cuse_server_write(struct dev_write_args *ap)
+{
+	return (ENXIO);
+}
+
+static int
+cuse_server_ioctl_copy_locked(struct cuse_server *pcs,
+    struct cuse_client_command *pccmd,
+    struct cuse_data_chunk *pchk, bool isread)
+{
+	struct proc *p_proc;
+	uint32_t offset;
+	int error;
+
+	offset = pchk->peer_ptr - CUSE_BUF_MIN_PTR;
+
+	if (pchk->length > CUSE_BUFFER_MAX)
+		return (EFAULT);
+
+	if (offset >= CUSE_BUFFER_MAX)
+		return (EFAULT);
+
+	if ((offset + pchk->length) > CUSE_BUFFER_MAX)
+		return (EFAULT);
+
+	p_proc = pccmd->proc_curr;
+	if (p_proc == NULL)
+		return (ENXIO);
+
+	if (pccmd->proc_refs < 0)
+		return (ENOMEM);
+
+	pccmd->proc_refs++;
+
+	cuse_server_unlock(pcs);
+
+	if (!isread) {
+		error = copyin(
+		    (void *)pchk->local_ptr,
+		    pccmd->client->ioctl_buffer + offset,
+		    pchk->length);
+	} else {
+		error = copyout(
+		    pccmd->client->ioctl_buffer + offset,
+		    (void *)pchk->local_ptr,
+		    pchk->length);
+	}
+
+	cuse_server_lock(pcs);
+
+	pccmd->proc_refs--;
+
+	if (pccmd->proc_curr == NULL)
+		cv_signal(&pccmd->cv);
+
+	return (error);
+}
+
+static int
+proc_rwmem_dfly(struct proc *p, struct uio *uio)
+{
+	struct iovec *iov = uio->uio_iov;
+	int error = 0;
+
+	if (uio->uio_rw == UIO_WRITE) {
+		error = copyin(iov->iov_base, (void *)uio->uio_offset, iov->iov_len);
+	} else {
+		error = copyout((void *)uio->uio_offset, iov->iov_base, iov->iov_len);
+	}
+
+	return error;
+}
+
+static int
+cuse_proc2proc_copy(struct proc *proc_s, vm_offset_t data_s,
+    struct proc *proc_d, vm_offset_t data_d, size_t len)
+{
+	struct thread *td;
+	struct proc *proc_cur;
+	int error;
+
+	td = curthread;
+	proc_cur = td->td_proc;
+
+	if (proc_cur == proc_d) {
+		struct iovec iov = {
+			.iov_base = (caddr_t)data_d,
+			.iov_len = len,
+		};
+		struct uio uio = {
+			.uio_iov = &iov,
+			.uio_iovcnt = 1,
+			.uio_offset = (off_t)data_s,
+			.uio_resid = len,
+			.uio_segflg = UIO_USERSPACE,
+			.uio_rw = UIO_READ,
+			.uio_td = td,
+		};
+
+		PHOLD(proc_s);
+		error = proc_rwmem_dfly(proc_s, &uio);
+		PRELE(proc_s);
+
+	} else if (proc_cur == proc_s) {
+		struct iovec iov = {
+			.iov_base = (caddr_t)data_s,
+			.iov_len = len,
+		};
+		struct uio uio = {
+			.uio_iov = &iov,
+			.uio_iovcnt = 1,
+			.uio_offset = (off_t)data_d,
+			.uio_resid = len,
+			.uio_segflg = UIO_USERSPACE,
+			.uio_rw = UIO_WRITE,
+			.uio_td = td,
+		};
+
+		PHOLD(proc_d);
+		error = proc_rwmem_dfly(proc_d, &uio);
+		PRELE(proc_d);
+	} else {
+		error = EINVAL;
+	}
+	return (error);
+}
+
+static int
+cuse_server_data_copy_locked(struct cuse_server *pcs,
+    struct cuse_client_command *pccmd,
+    struct cuse_data_chunk *pchk, bool isread)
+{
+	struct proc *p_proc;
+	int error;
+
+	p_proc = pccmd->proc_curr;
+	if (p_proc == NULL)
+		return (ENXIO);
+
+	if (pccmd->proc_refs < 0)
+		return (ENOMEM);
+
+	pccmd->proc_refs++;
+
+	cuse_server_unlock(pcs);
+
+	if (!isread) {
+		error = cuse_proc2proc_copy(
+		    curthread->td_proc, pchk->local_ptr,
+		    p_proc, pchk->peer_ptr,
+		    pchk->length);
+	} else {
+		error = cuse_proc2proc_copy(
+		    p_proc, pchk->peer_ptr,
+		    curthread->td_proc, pchk->local_ptr,
+		    pchk->length);
+	}
+
+	cuse_server_lock(pcs);
+
+	pccmd->proc_refs--;
+
+	if (pccmd->proc_curr == NULL)
+		cv_signal(&pccmd->cv);
+
+	return (error);
+}
+
+static int
+cuse_server_data_copy_optimized_locked(struct cuse_server *pcs,
+    struct cuse_client_command *pccmd,
+    struct cuse_data_chunk *pchk, bool isread)
+{
+	uintptr_t offset;
+	int error;
+
+	/*
+	 * Check if data is stored locally to avoid accessing
+	 * other process's data space:
+	 */
+	if (isread) {
+		offset = pchk->peer_ptr - pccmd->client->write_base;
+
+		if (offset < (uintptr_t)pccmd->client->write_length &&
+		    pchk->length <= (unsigned long)pccmd->client->write_length &&
+		    offset + pchk->length <= (uintptr_t)pccmd->client->write_length) {
+			cuse_server_unlock(pcs);
+			error = copyout(pccmd->client->write_buffer + offset,
+			    (void *)pchk->local_ptr, pchk->length);
+			goto done;
+		}
+	} else {
+		offset = pchk->peer_ptr - pccmd->client->read_base;
+
+		if (offset < (uintptr_t)pccmd->client->read_length &&
+		    pchk->length <= (unsigned long)pccmd->client->read_length &&
+		    offset + pchk->length <= (uintptr_t)pccmd->client->read_length) {
+			cuse_server_unlock(pcs);
+			error = copyin((void *)pchk->local_ptr,
+			    pccmd->client->read_buffer + offset, pchk->length);
+			goto done;
+		}
+	}
+
+	/* use process to process copy function */
+	error = cuse_server_data_copy_locked(pcs, pccmd, pchk, isread);
+done:
+	return (error);
+}
+
+static int
+cuse_alloc_unit_by_id_locked(struct cuse_server *pcs, int id)
+{
+	int n;
+	int x = 0;
+	int match;
+
+	do {
+		for (match = n = 0; n != CUSE_DEVICES_MAX; n++) {
+			if (cuse_alloc_unit[n] != NULL) {
+				if ((cuse_alloc_unit_id[n] ^ id) & CUSE_ID_MASK)
+					continue;
+				if ((cuse_alloc_unit_id[n] & ~CUSE_ID_MASK) == x) {
+					x++;
+					match = 1;
+				}
+			}
+		}
+	} while (match);
+
+	if (x < 256) {
+		for (n = 0; n != CUSE_DEVICES_MAX; n++) {
+			if (cuse_alloc_unit[n] == NULL) {
+				cuse_alloc_unit[n] = pcs;
+				cuse_alloc_unit_id[n] = id | x;
+				return (x);
+			}
+		}
+	}
+	return (-1);
+}
+
+static void
+cuse_server_wakeup_locked(struct cuse_server *pcs)
+{
+#if 0
+	/* This becomes noop due to no poll() */
+	selwakeup(&pcs->selinfo);
+#endif
+	KNOTE(&pcs->selinfo.ki_note, 0);
+}
+
+static void
+cuse_server_wakeup_all_client_locked(struct cuse_server *pcs)
+{
+	struct cuse_client *pcc;
+
+	TAILQ_FOREACH(pcc, &pcs->hcli, entry) {
+		pcc->cflags |= (CUSE_CLI_KNOTE_NEED_READ |
+		    CUSE_CLI_KNOTE_NEED_WRITE);
+	}
+	cuse_server_wakeup_locked(pcs);
+}
+
+static int
+cuse_free_unit_by_id_locked(struct cuse_server *pcs, int id)
+{
+	int n;
+	int found = 0;
+
+	for (n = 0; n != CUSE_DEVICES_MAX; n++) {
+		if (cuse_alloc_unit[n] == pcs) {
+			if (cuse_alloc_unit_id[n] == id || id == -1) {
+				cuse_alloc_unit[n] = NULL;
+				cuse_alloc_unit_id[n] = 0;
+				found = 1;
+			}
+		}
+	}
+
+	return (found ? 0 : EINVAL);
+}
+
+static int
+cuse_server_ioctl(struct dev_ioctl_args *ap)
+{
+        u_long cmd = ap->a_cmd;
+        caddr_t data = ap->a_data;
+
+	struct cuse_server *pcs;
+	int error;
+
+	error = cuse_server_get(ap->a_fp, &pcs);
+	if (error != 0)
+		return (error);
+
+	switch (cmd) {
+		struct cuse_client_command *pccmd;
+		struct cuse_client *pcc;
+		struct cuse_command *pcmd;
+		struct cuse_alloc_info *pai;
+		struct cuse_create_dev *pcd;
+		struct cuse_server_dev *pcsd;
+		struct cuse_data_chunk *pchk;
+		int n;
+
+	case CUSE_IOCTL_GET_COMMAND:
+		pcmd = (void *)data;
+
+		cuse_server_lock(pcs);
+
+		while ((pccmd = TAILQ_FIRST(&pcs->head)) == NULL) {
+			error = cv_wait_sig(&pcs->cv, &pcs->mtx);
+
+			if (pcs->is_closing)
+				error = ENXIO;
+
+			if (error) {
+				cuse_server_unlock(pcs);
+				return (error);
+			}
+		}
+
+		TAILQ_REMOVE(&pcs->head, pccmd, entry);
+		pccmd->entry.tqe_prev = NULL;
+
+		pccmd->entered = curthread;
+
+		*pcmd = pccmd->sub;
+
+		cuse_server_unlock(pcs);
+
+		break;
+
+	case CUSE_IOCTL_SYNC_COMMAND:
+
+		cuse_server_lock(pcs);
+		while ((pccmd = cuse_server_find_command(pcs, curthread)) != NULL) {
+			/* send sync command */
+			pccmd->entered = NULL;
+			pccmd->error = *(int *)data;
+			pccmd->command = CUSE_CMD_SYNC;
+
+			/* signal peer, if any */
+			cv_signal(&pccmd->cv);
+		}
+		cuse_server_unlock(pcs);
+
+		break;
+
+	case CUSE_IOCTL_ALLOC_UNIT:
+
+		cuse_server_lock(pcs);
+		n = cuse_alloc_unit_by_id_locked(pcs,
+		    CUSE_ID_DEFAULT(0));
+		cuse_server_unlock(pcs);
+
+		if (n < 0)
+			error = ENOMEM;
+		else
+			*(int *)data = n;
+		break;
+
+	case CUSE_IOCTL_ALLOC_UNIT_BY_ID:
+
+		n = *(int *)data;
+
+		n = (n & CUSE_ID_MASK);
+
+		cuse_server_lock(pcs);
+		n = cuse_alloc_unit_by_id_locked(pcs, n);
+		cuse_server_unlock(pcs);
+
+		if (n < 0)
+			error = ENOMEM;
+		else
+			*(int *)data = n;
+		break;
+
+	case CUSE_IOCTL_FREE_UNIT:
+
+		n = *(int *)data;
+
+		n = CUSE_ID_DEFAULT(n);
+
+		cuse_server_lock(pcs);
+		error = cuse_free_unit_by_id_locked(pcs, n);
+		cuse_server_unlock(pcs);
+		break;
+
+	case CUSE_IOCTL_FREE_UNIT_BY_ID:
+
+		n = *(int *)data;
+
+		cuse_server_lock(pcs);
+		error = cuse_free_unit_by_id_locked(pcs, n);
+		cuse_server_unlock(pcs);
+		break;
+
+	case CUSE_IOCTL_ALLOC_MEMORY:
+
+		pai = (void *)data;
+
+		if (pai->alloc_nr >= CUSE_ALLOC_UNIT_MAX) {
+			error = ENOMEM;
+			break;
+		}
+		if (pai->page_count > CUSE_ALLOC_PAGES_MAX) {
+			error = ENOMEM;
+			break;
+		}
+		error = cuse_server_alloc_memory(pcs,
+		    pai->alloc_nr, pai->page_count);
+		break;
+
+	case CUSE_IOCTL_FREE_MEMORY:
+		pai = (void *)data;
+
+		if (pai->alloc_nr >= CUSE_ALLOC_UNIT_MAX) {
+			error = ENOMEM;
+			break;
+		}
+		error = cuse_server_free_memory(pcs, pai->alloc_nr);
+		break;
+
+	case CUSE_IOCTL_GET_SIG:
+
+		cuse_server_lock(pcs);
+		pccmd = cuse_server_find_command(pcs, curthread);
+
+		if (pccmd != NULL) {
+			n = pccmd->got_signal;
+			pccmd->got_signal = 0;
+		} else {
+			n = 0;
+		}
+		cuse_server_unlock(pcs);
+
+		*(int *)data = n;
+
+		break;
+
+	case CUSE_IOCTL_SET_PFH:
+
+		cuse_server_lock(pcs);
+		pccmd = cuse_server_find_command(pcs, curthread);
+
+		if (pccmd != NULL) {
+			pcc = pccmd->client;
+			for (n = 0; n != CUSE_CMD_MAX; n++) {
+				pcc->cmds[n].sub.per_file_handle = *(uintptr_t *)data;
+			}
+		} else {
+			error = ENXIO;
+		}
+		cuse_server_unlock(pcs);
+		break;
+
+	case CUSE_IOCTL_CREATE_DEV:
+
+		error = caps_priv_check_self(SYSCAP_NODRIVER);
+		if (error)
+			break;
+
+		pcd = (void *)data;
+
+		/* filter input */
+
+		pcd->devname[sizeof(pcd->devname) - 1] = 0;
+
+		if (pcd->devname[0] == 0) {
+			error = EINVAL;
+			break;
+		}
+		cuse_str_filter(pcd->devname);
+
+		pcd->permissions &= 0777;
+
+		/* try to allocate a character device */
+
+		pcsd = kmalloc(sizeof(*pcsd), M_CUSE, M_WAITOK | M_ZERO);
+
+		pcsd->server = pcs;
+
+		pcsd->user_dev = pcd->dev;
+
+		pcsd->kern_dev = make_dev(&cuse_client_devsw, 0,
+					UID_ROOT, GID_OPERATOR, pcd->permissions,
+					"%s", pcd->devname);
+
+		if (pcsd->kern_dev == NULL) {
+			kfree(pcsd, M_CUSE);
+			error = ENOMEM;
+			break;
+		}
+		pcsd->kern_dev->si_drv1 = pcsd;
+
+		cuse_server_lock(pcs);
+		TAILQ_INSERT_TAIL(&pcs->hdev, pcsd, entry);
+		cuse_server_unlock(pcs);
+
+		break;
+
+	case CUSE_IOCTL_DESTROY_DEV:
+
+		error = caps_priv_check_self(SYSCAP_NODRIVER);
+		if (error)
+			break;
+
+		cuse_server_lock(pcs);
+
+		error = EINVAL;
+
+		pcsd = TAILQ_FIRST(&pcs->hdev);
+		while (pcsd != NULL) {
+			if (pcsd->user_dev == *(struct cuse_dev **)data) {
+				TAILQ_REMOVE(&pcs->hdev, pcsd, entry);
+				cuse_server_unlock(pcs);
+				cuse_server_free_dev(pcsd);
+				cuse_server_lock(pcs);
+				error = 0;
+				pcsd = TAILQ_FIRST(&pcs->hdev);
+			} else {
+				pcsd = TAILQ_NEXT(pcsd, entry);
+			}
+		}
+
+		cuse_server_unlock(pcs);
+		break;
+
+	case CUSE_IOCTL_WRITE_DATA:
+	case CUSE_IOCTL_READ_DATA:
+
+		cuse_server_lock(pcs);
+		pchk = (struct cuse_data_chunk *)data;
+
+		pccmd = cuse_server_find_command(pcs, curthread);
+
+		if (pccmd == NULL) {
+			error = ENXIO;	/* invalid request */
+		} else if (pchk->peer_ptr < CUSE_BUF_MIN_PTR) {
+			error = EFAULT;	/* NULL pointer */
+		} else if (pchk->length == 0) {
+			/* NOP */
+		} else if (pchk->peer_ptr < CUSE_BUF_MAX_PTR) {
+			error = cuse_server_ioctl_copy_locked(pcs, pccmd,
+			    pchk, cmd == CUSE_IOCTL_READ_DATA);
+		} else {
+			error = cuse_server_data_copy_optimized_locked(
+			    pcs, pccmd, pchk, cmd == CUSE_IOCTL_READ_DATA);
+		}
+
+		/*
+		 * Sometimes the functions above drop the server lock
+		 * early as an optimization:
+		 */
+		if (cuse_server_is_locked(pcs))
+			cuse_server_unlock(pcs);
+		break;
+
+	case CUSE_IOCTL_SELWAKEUP:
+		cuse_server_lock(pcs);
+		/*
+		 * We don't know which direction caused the event.
+		 * Wakeup both!
+		 */
+		cuse_server_wakeup_all_client_locked(pcs);
+		cuse_server_unlock(pcs);
+		break;
+
+	default:
+		error = ENXIO;
+		break;
+	}
+	return (error);
+}
+
+#if 0
+static int
+cuse_server_poll(struct cdev *dev, int events, struct thread *td)
+{
+	return (events & (POLLHUP | POLLPRI | POLLIN |
+	    POLLRDNORM | POLLOUT | POLLWRNORM));
+}
+#endif
+
+static int
+cuse_common_mmap_single(struct cuse_server *pcs,
+    vm_ooffset_t *offset, vm_size_t size, struct vm_object **object)
+{
+  	struct cuse_memory *mem;
+	int error;
+
+	/* verify size */
+	if ((size % PAGE_SIZE) != 0 || (size < PAGE_SIZE))
+		return (EINVAL);
+
+	cuse_server_lock(pcs);
+	error = ENOMEM;
+
+	/* lookup memory structure, if any */
+	TAILQ_FOREACH(mem, &pcs->hmem, entry) {
+		vm_ooffset_t min_off;
+		vm_ooffset_t max_off;
+
+		min_off = (mem->alloc_nr << CUSE_ALLOC_UNIT_SHIFT);
+		max_off = min_off + (PAGE_SIZE * mem->page_count);
+
+		if (*offset >= min_off && *offset < max_off) {
+			/* range check size */
+			if (size > (max_off - *offset)) {
+				error = EINVAL;
+			} else {
+				/* get new VM object offset to use */
+				*offset -= min_off;
+				vm_object_reference_quick(mem->object);
+				*object = mem->object;
+				error = 0;
+			}
+			break;
+		}
+	}
+	cuse_server_unlock(pcs);
+	return (error);
+}
+
+static int
+cuse_server_mmap_single(struct dev_mmap_single_args *ap)
+{
+	vm_ooffset_t *offset = ap->a_offset;
+	vm_size_t size = ap->a_size;
+	struct vm_object **object = ap->a_object;
+
+	struct cuse_server *pcs;
+	int error;
+
+	error = cuse_server_get(ap->a_fp, &pcs);
+	if (error != 0)
+		return (error);
+
+	return (cuse_common_mmap_single(pcs, offset, size, object));
+}
+
+/*------------------------------------------------------------------------*
+ *	CUSE CLIENT PART
+ *------------------------------------------------------------------------*/
+static void
+cuse_client_free(void *arg)
+{
+	struct cuse_client *pcc = arg;
+	struct cuse_client_command *pccmd;
+	struct cuse_server *pcs;
+	int n;
+
+	pcs = pcc->server;
+
+	cuse_server_lock(pcs);
+	cuse_client_is_closing(pcc);
+	TAILQ_REMOVE(&pcs->hcli, pcc, entry);
+	cuse_server_unlock(pcs);
+
+	for (n = 0; n != CUSE_CMD_MAX; n++) {
+		pccmd = &pcc->cmds[n];
+
+		lockuninit(&pccmd->sx);
+		cv_destroy(&pccmd->cv);
+	}
+
+	kfree(pcc, M_CUSE);
+
+	/* drop reference on server */
+	cuse_server_unref(pcs);
+}
+
+static int
+cuse_client_open(struct dev_open_args *ap)
+{
+	struct cdev *dev = ap->a_head.a_dev;
+	struct cuse_client_command *pccmd;
+	int fflags = ap->a_oflags;
+	struct cuse_server_dev *pcsd;
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	struct cuse_dev *pcd;
+	int error;
+	int n;
+
+	pcsd = dev->si_drv1;
+	if (pcsd != NULL) {
+		pcs = pcsd->server;
+		pcd = pcsd->user_dev;
+
+		cuse_server_lock(pcs);
+		/*
+		 * Check that the refcount didn't wrap and that the
+		 * same process is not both client and server. This
+		 * can easily lead to deadlocks when destroying the
+		 * CUSE character device nodes:
+		 */
+		pcs->refs++;
+		if (pcs->refs < 0 || pcs->pid == curproc->p_pid) {
+			/* overflow or wrong PID */
+			pcs->refs--;
+			cuse_server_unlock(pcs);
+			return (EINVAL);
+		}
+		cuse_server_unlock(pcs);
+	} else {
+		return (EINVAL);
+	}
+
+	pcc = kmalloc(sizeof(*pcc), M_CUSE, M_WAITOK | M_ZERO);
+	if (devfs_set_cdevpriv(*ap->a_fpp, pcc, &cuse_client_free)) {
+		kprintf("Cuse: Cannot set cdevpriv.\n");
+		/* drop reference on server */
+		cuse_server_unref(pcs);
+		kfree(pcc, M_CUSE);
+		return (ENOMEM);
+	}
+	pcc->fflags = fflags;
+	pcc->server_dev = pcsd;
+	pcc->server = pcs;
+
+	for (n = 0; n != CUSE_CMD_MAX; n++) {
+		pccmd = &pcc->cmds[n];
+
+		pccmd->sub.dev = pcd;
+		pccmd->sub.command = n;
+		pccmd->client = pcc;
+
+		lockinit(&pccmd->sx, "cuse-client-sx", 0, 0);
+		cv_init(&pccmd->cv, "cuse-client-cv");
+	}
+
+	cuse_server_lock(pcs);
+
+	/* cuse_client_free() assumes that the client is listed somewhere! */
+	/* always enqueue */
+
+	TAILQ_INSERT_TAIL(&pcs->hcli, pcc, entry);
+
+	/* check if server is closing */
+	if ((pcs->is_closing != 0) || (dev->si_drv1 == NULL)) {
+		error = EINVAL;
+	} else {
+		error = 0;
+	}
+	cuse_server_unlock(pcs);
+
+	if (error) {
+		devfs_clear_cdevpriv(*ap->a_fpp);	/* XXX bugfix */
+		return (error);
+	}
+	pccmd = &pcc->cmds[CUSE_CMD_OPEN];
+
+	cuse_cmd_lock(pccmd);
+
+	cuse_server_lock(pcs);
+	cuse_client_send_command_locked(pccmd, 0, 0, pcc->fflags, 0);
+
+	error = cuse_client_receive_command_locked(pccmd, 0, 0);
+	cuse_server_unlock(pcs);
+
+	if (error < 0) {
+		error = cuse_convert_error(error);
+	} else {
+		error = 0;
+	}
+
+	cuse_cmd_unlock(pccmd);
+
+	if (error)
+		devfs_clear_cdevpriv(*ap->a_fpp);	/* XXX bugfix */
+
+	return (error);
+}
+
+static int
+cuse_client_close(struct dev_close_args *ap)
+{
+	struct cuse_client_command *pccmd;
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	int error;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (0);
+
+	pccmd = &pcc->cmds[CUSE_CMD_CLOSE];
+	pcs = pcc->server;
+
+	cuse_cmd_lock(pccmd);
+
+	cuse_server_lock(pcs);
+	cuse_client_send_command_locked(pccmd, 0, 0, pcc->fflags, 0);
+
+	error = cuse_client_receive_command_locked(pccmd, 0, 0);
+	cuse_cmd_unlock(pccmd);
+
+	cuse_client_is_closing(pcc);
+	cuse_server_unlock(pcs);
+
+	return (0);
+}
+
+static int
+cuse_client_poll(struct file *fp, struct cdev *dev, int events)
+{
+        struct cuse_client_command *pccmd;
+        struct cuse_client *pcc;
+        struct cuse_server *pcs;
+        unsigned long temp;
+        int error;
+        int revents;
+
+        error = cuse_client_get(fp, &pcc);
+        if (error != 0)
+                goto pollnval;
+
+        temp = 0;
+        pcs = pcc->server;
+
+        if (events & (POLLPRI | POLLIN | POLLRDNORM))
+                temp |= CUSE_POLL_READ;
+
+        if (events & (POLLOUT | POLLWRNORM))
+                temp |= CUSE_POLL_WRITE;
+
+        if (events & POLLHUP)
+                temp |= CUSE_POLL_ERROR;
+
+        pccmd = &pcc->cmds[CUSE_CMD_POLL];
+
+        cuse_cmd_lock(pccmd);
+
+        cuse_server_lock(pcs);
+        cuse_client_send_command_locked(pccmd,
+            0, temp, pcc->fflags, IO_NDELAY);
+
+        error = cuse_client_receive_command_locked(pccmd, 0, 0);
+        cuse_server_unlock(pcs);
+
+        cuse_cmd_unlock(pccmd);
+
+        if (error < 0) {
+                goto pollnval;
+        } else {
+                revents = 0;
+                if (error & CUSE_POLL_READ)
+                        revents |= (events & (POLLPRI | POLLIN | POLLRDNORM));
+                if (error & CUSE_POLL_WRITE)
+                        revents |= (events & (POLLOUT | POLLWRNORM));
+                if (error & CUSE_POLL_ERROR)
+                        revents |= (events & POLLHUP);
+        }
+        return (revents);
+
+pollnval:
+        /* XXX many clients don't understand POLLNVAL */
+        return (events & (POLLHUP | POLLPRI | POLLIN |
+            POLLRDNORM | POLLOUT | POLLWRNORM));
+}
+
+static void
+cuse_client_kqfilter_poll(struct file *fp, struct cdev *dev, struct cuse_client *pcc)
+{
+	struct cuse_server *pcs = pcc->server;
+	int temp;
+
+	cuse_server_lock(pcs);
+	temp = (pcc->cflags & (CUSE_CLI_KNOTE_HAS_READ |
+	    CUSE_CLI_KNOTE_HAS_WRITE));
+	pcc->cflags &= ~(CUSE_CLI_KNOTE_NEED_READ |
+	    CUSE_CLI_KNOTE_NEED_WRITE);
+	cuse_server_unlock(pcs);
+
+	if (temp != 0) {
+		/* get the latest polling state from the server */
+		temp = cuse_client_poll(fp, dev, 0);
+
+		if (temp & (POLLIN | POLLOUT)) {
+			cuse_server_lock(pcs);
+			if (temp & POLLIN)
+				pcc->cflags |= CUSE_CLI_KNOTE_NEED_READ;
+			if (temp & POLLOUT)
+				pcc->cflags |= CUSE_CLI_KNOTE_NEED_WRITE;
+
+			/* make sure the "knote" gets woken up */
+			cuse_server_wakeup_locked(pcc->server);
+			cuse_server_unlock(pcs);
+		}
+	}
+}
+
+static int
+cuse_client_read(struct dev_read_args *ap)
+{
+	struct cdev *dev = ap->a_head.a_dev;
+	int ioflag = ap->a_ioflag;
+	struct uio *uio = ap->a_uio;
+	struct cuse_client_command *pccmd;
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	int error;
+	int temp;
+	int len;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (error);
+
+	pccmd = &pcc->cmds[CUSE_CMD_READ];
+	pcs = pcc->server;
+
+	if (uio->uio_segflg != UIO_USERSPACE) {
+		return (EINVAL);
+	}
+	uio->uio_segflg = UIO_NOCOPY;
+
+	cuse_cmd_lock(pccmd);
+
+	while (uio->uio_resid != 0) {
+		if (uio->uio_iov->iov_len > CUSE_LENGTH_MAX) {
+			error = ENOMEM;
+			break;
+		}
+		len = uio->uio_iov->iov_len;
+
+		cuse_server_lock(pcs);
+		if (len <= CUSE_COPY_BUFFER_MAX) {
+			/* set read buffer region for small reads */
+			pcc->read_base = (uintptr_t)uio->uio_iov->iov_base;
+			pcc->read_length = len;
+		}
+		cuse_client_send_command_locked(pccmd,
+		    (uintptr_t)uio->uio_iov->iov_base,
+		    (unsigned long)(unsigned int)len, pcc->fflags, ioflag);
+
+		error = cuse_client_receive_command_locked(pccmd, 0, 0);
+		/*
+		 * After finishing reading data, disable the read
+		 * region for the cuse_server_data_copy_optimized_locked()
+		 * function:
+		 */
+		pcc->read_base = 0;
+		pcc->read_length = 0;
+		cuse_server_unlock(pcs);
+
+		/*
+		 * The return value indicates the read length, when
+		 * not negative. Range check it just in case to avoid
+		 * passing invalid length values to uiomove().
+		 */
+		if (error > len) {
+			error = ERANGE;
+			break;
+		} else if (error > 0 && len <= CUSE_COPY_BUFFER_MAX) {
+			temp = copyout(pcc->read_buffer,
+			    uio->uio_iov->iov_base, error);
+			if (temp != 0) {
+				error = temp;
+				break;
+			}
+		}
+		if (error < 0) {
+			error = cuse_convert_error(error);
+			break;
+		} else if (error == len) {
+			error = uiomove(NULL, error, uio);
+			if (error)
+				break;
+		} else {
+			error = uiomove(NULL, error, uio);
+			break;
+		}
+	}
+	cuse_cmd_unlock(pccmd);
+
+	uio->uio_segflg = UIO_USERSPACE;/* restore segment flag */
+
+	if (error == EWOULDBLOCK)
+		cuse_client_kqfilter_poll(ap->a_fp, dev, pcc);
+
+	return (error);
+}
+
+static int
+cuse_client_write(struct dev_write_args *ap)
+{
+	struct cdev *dev = ap->a_head.a_dev;
+	struct uio *uio = ap->a_uio;
+	struct cuse_client_command *pccmd;
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	int ioflag = ap->a_ioflag;
+	int error;
+	int len;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (error);
+
+	pccmd = &pcc->cmds[CUSE_CMD_WRITE];
+	pcs = pcc->server;
+
+	if (uio->uio_segflg != UIO_USERSPACE) {
+		return (EINVAL);
+	}
+	uio->uio_segflg = UIO_NOCOPY;
+
+	cuse_cmd_lock(pccmd);
+
+	while (uio->uio_resid != 0) {
+		if (uio->uio_iov->iov_len > CUSE_LENGTH_MAX) {
+			error = ENOMEM;
+			break;
+		}
+		len = uio->uio_iov->iov_len;
+
+		if (len <= CUSE_COPY_BUFFER_MAX) {
+			error = copyin(uio->uio_iov->iov_base,
+			    pcc->write_buffer, len);
+			if (error != 0)
+				break;
+		}
+
+		cuse_server_lock(pcs);
+		if (len <= CUSE_COPY_BUFFER_MAX) {
+			/* set write buffer region for small writes */
+			pcc->write_base = (uintptr_t)uio->uio_iov->iov_base;
+			pcc->write_length = len;
+		}
+		cuse_client_send_command_locked(pccmd,
+		    (uintptr_t)uio->uio_iov->iov_base,
+		    (unsigned long)(unsigned int)len, pcc->fflags, ioflag);
+
+		error = cuse_client_receive_command_locked(pccmd, 0, 0);
+
+		/*
+		 * After finishing writing data, disable the write
+		 * region for the cuse_server_data_copy_optimized_locked()
+		 * function:
+		 */
+		pcc->write_base = 0;
+		pcc->write_length = 0;
+		cuse_server_unlock(pcs);
+
+		/*
+		 * The return value indicates the write length, when
+		 * not negative. Range check it just in case to avoid
+		 * passing invalid length values to uiomove().
+		 */
+		if (error > len) {
+			error = ERANGE;
+			break;
+		} else if (error < 0) {
+			error = cuse_convert_error(error);
+			break;
+		} else if (error == len) {
+			error = uiomove(NULL, error, uio);
+			if (error)
+				break;
+		} else {
+			error = uiomove(NULL, error, uio);
+			break;
+		}
+	}
+	cuse_cmd_unlock(pccmd);
+
+	/* restore segment flag */
+	uio->uio_segflg = UIO_USERSPACE;
+
+	if (error == EWOULDBLOCK)
+		cuse_client_kqfilter_poll(ap->a_fp, dev, pcc);
+
+	return (error);
+}
+
+int
+cuse_client_ioctl(struct dev_ioctl_args *ap)
+{
+	struct cdev *dev = ap->a_head.a_dev;
+        int fflags = ap->a_fflag;
+	u_long cmd = ap->a_cmd;
+	caddr_t data = ap->a_data;
+
+	struct cuse_client_command *pccmd;
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	int error;
+	int len;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (error);
+
+	len = IOCPARM_LEN(cmd);
+	if (len > CUSE_BUFFER_MAX)
+		return (ENOMEM);
+
+	pccmd = &pcc->cmds[CUSE_CMD_IOCTL];
+	pcs = pcc->server;
+
+	cuse_cmd_lock(pccmd);
+
+	if (cmd & (IOC_IN | IOC_VOID))
+		memcpy(pcc->ioctl_buffer, data, len);
+
+	/*
+	 * When the ioctl-length is zero drivers can pass information
+	 * through the data pointer of the ioctl. Make sure this information
+	 * is forwarded to the driver.
+	 */
+
+	cuse_server_lock(pcs);
+	cuse_client_send_command_locked(pccmd,
+	    (len == 0) ? *(long *)data : CUSE_BUF_MIN_PTR,
+	    (unsigned long)cmd, pcc->fflags,
+	    (fflags & O_NONBLOCK) ? IO_NDELAY : 0);
+
+	error = cuse_client_receive_command_locked(pccmd, data, len);
+	cuse_server_unlock(pcs);
+
+	if (error < 0) {
+		error = cuse_convert_error(error);
+	} else {
+		error = 0;
+	}
+
+	if (cmd & IOC_OUT)
+		memcpy(data, pcc->ioctl_buffer, len);
+
+	cuse_cmd_unlock(pccmd);
+
+	if (error == EWOULDBLOCK)
+		cuse_client_kqfilter_poll(ap->a_fp, dev, pcc);
+
+	return (error);
+}
+
+static int
+cuse_client_mmap_single(struct dev_mmap_single_args *ap)
+{
+        vm_ooffset_t *offset = ap->a_offset;
+        vm_size_t size = ap->a_size;
+        struct vm_object **object = ap->a_object;
+
+	struct cuse_client *pcc;
+	int error;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (error);
+
+	return (cuse_common_mmap_single(pcc->server, offset, size, object));
+}
+
+static void
+cuse_client_kqfilter_read_detach(struct knote *kn)
+{
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+
+	pcc = (struct cuse_client *)kn->kn_hook;
+	pcs = pcc->server;
+
+	cuse_server_lock(pcs);
+	knote_remove(&pcs->selinfo.ki_note, kn);
+	cuse_server_unlock(pcs);
+}
+
+static void
+cuse_client_kqfilter_write_detach(struct knote *kn)
+{
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+
+	pcc = (struct cuse_client *)kn->kn_hook;
+	pcs = pcc->server;
+
+	cuse_server_lock(pcs);
+	knote_remove(&pcs->selinfo.ki_note, kn);
+	cuse_server_unlock(pcs);
+}
+
+static int
+cuse_client_kqfilter_read_event(struct knote *kn, long hint)
+{
+	struct cuse_client *pcc;
+
+	pcc = (struct cuse_client *)kn->kn_hook;
+
+	KKASSERT(lockstatus(&pcc->server->mtx, curthread) != 0);
+
+	return ((pcc->cflags & CUSE_CLI_KNOTE_NEED_READ) ? 1 : 0);
+}
+
+static int
+cuse_client_kqfilter_write_event(struct knote *kn, long hint)
+{
+	struct cuse_client *pcc;
+
+	pcc = (struct cuse_client *)kn->kn_hook;
+
+        KKASSERT(lockstatus(&pcc->server->mtx, curthread) != 0);
+
+	return ((pcc->cflags & CUSE_CLI_KNOTE_NEED_WRITE) ? 1 : 0);
+}
+
+static int
+cuse_client_kqfilter(struct dev_kqfilter_args *ap)
+{
+	struct knote *kn = ap->a_kn;
+	struct cdev *dev = ap->a_head.a_dev;
+
+	struct cuse_client *pcc;
+	struct cuse_server *pcs;
+	int error;
+
+	error = cuse_client_get(ap->a_fp, &pcc);
+	if (error != 0)
+		return (error);
+
+	pcs = pcc->server;
+
+	cuse_server_lock(pcs);
+	switch (kn->kn_filter) {
+	case EVFILT_READ:
+		pcc->cflags |= CUSE_CLI_KNOTE_HAS_READ;
+		kn->kn_hook = (caddr_t)pcc;
+		kn->kn_fop = &cuse_client_kqfilter_read_ops;
+		knote_insert(&pcs->selinfo.ki_note, kn);
+		break;
+	case EVFILT_WRITE:
+		pcc->cflags |= CUSE_CLI_KNOTE_HAS_WRITE;
+		kn->kn_hook = (caddr_t)pcc;
+		kn->kn_fop = &cuse_client_kqfilter_write_ops;
+		knote_insert(&pcs->selinfo.ki_note, kn);
+		break;
+	default:
+		error = EINVAL;
+		break;
+	}
+	cuse_server_unlock(pcs);
+
+	if (error == 0)
+		cuse_client_kqfilter_poll(ap->a_fp, dev, pcc);
+	return (error);
+}

--- a/sys/vfs/cuse/cuse_defs.h
+++ b/sys/vfs/cuse/cuse_defs.h
@@ -1,0 +1,87 @@
+/*-
+ * Copyright (c) 2010-2012 Hans Petter Selasky. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _CUSE_DEFS_H_
+#define	_CUSE_DEFS_H_
+
+#define	CUSE_VERSION		0x000125
+
+#define	CUSE_ERR_NONE		0
+#define	CUSE_ERR_BUSY		-1
+#define	CUSE_ERR_WOULDBLOCK	-2
+#define	CUSE_ERR_INVALID	-3
+#define	CUSE_ERR_NO_MEMORY	-4
+#define	CUSE_ERR_FAULT		-5
+#define	CUSE_ERR_SIGNAL		-6
+#define	CUSE_ERR_OTHER		-7
+#define	CUSE_ERR_NOT_LOADED	-8
+#define	CUSE_ERR_NO_DEVICE	-9
+
+#define	CUSE_POLL_NONE		0
+#define	CUSE_POLL_READ		1
+#define	CUSE_POLL_WRITE		2
+#define	CUSE_POLL_ERROR		4
+
+#define	CUSE_FFLAG_NONE		0
+#define	CUSE_FFLAG_READ		1
+#define	CUSE_FFLAG_WRITE	2
+#define	CUSE_FFLAG_NONBLOCK	4
+#define	CUSE_FFLAG_COMPAT32	8 /* peer is running in 32-bit compat mode */
+
+#define	CUSE_DBG_NONE		0
+#define	CUSE_DBG_FULL		1
+
+/* maximum data transfer length */
+#define	CUSE_LENGTH_MAX		0x7FFFFFFFU
+
+enum {
+	CUSE_CMD_NONE,
+	CUSE_CMD_OPEN,
+	CUSE_CMD_CLOSE,
+	CUSE_CMD_READ,
+	CUSE_CMD_WRITE,
+	CUSE_CMD_IOCTL,
+	CUSE_CMD_POLL,
+	CUSE_CMD_SIGNAL,
+	CUSE_CMD_SYNC,
+	CUSE_CMD_MAX,
+};
+
+#define	CUSE_MAKE_ID(a,b,c,u) ((((a) & 0x7F) << 24)| \
+    (((b) & 0xFF) << 16)|(((c) & 0xFF) << 8)|((u) & 0xFF))
+
+#define	CUSE_ID_MASK 0x7FFFFF00U
+
+/*
+ * The following ID's are defined:
+ * ===============================
+ */
+#define	CUSE_ID_DEFAULT(what) CUSE_MAKE_ID(0,0,what,0)
+#define	CUSE_ID_WEBCAMD(what) CUSE_MAKE_ID('W','C',what,0)	/* Used by Webcamd. */
+#define	CUSE_ID_SUNDTEK(what) CUSE_MAKE_ID('S','K',what,0)	/* Used by Sundtek. */
+#define	CUSE_ID_CX88(what) CUSE_MAKE_ID('C','X',what,0)		/* Used by cx88 driver. */
+#define	CUSE_ID_UHIDD(what) CUSE_MAKE_ID('U','D',what,0)	/* Used by uhidd. */
+
+#endif					/* _CUSE_DEFS_H_ */

--- a/sys/vfs/cuse/cuse_ioctl.h
+++ b/sys/vfs/cuse/cuse_ioctl.h
@@ -1,0 +1,90 @@
+/*-
+ * Copyright (c) 2014-2022 Hans Petter Selasky. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _CUSE_IOCTL_H_
+#define	_CUSE_IOCTL_H_
+
+#include <sys/ioccom.h>
+#include <sys/types.h>
+
+#define	CUSE_BUFFER_MAX		(1 << 12)	/* bytes */
+#define	CUSE_DEVICES_MAX	64	/* units */
+#define	CUSE_BUF_MIN_PTR	0x10000UL
+#define	CUSE_BUF_MAX_PTR	0x20000UL
+#define	CUSE_ALLOC_UNIT_MAX	128UL	/* units */
+#define	CUSE_ALLOC_UNIT_SHIFT	24	/* bits */
+/* All memory allocations must be less than the following limit */
+#define	CUSE_ALLOC_BYTES_MAX \
+    (CUSE_ALLOC_UNIT_MAX << CUSE_ALLOC_UNIT_SHIFT) /* bytes */
+
+struct cuse_dev;
+
+struct cuse_data_chunk {
+	uintptr_t local_ptr;
+	uintptr_t peer_ptr;
+	unsigned long length;
+};
+
+struct cuse_alloc_info {
+	unsigned long page_count;
+	unsigned long alloc_nr;
+};
+
+struct cuse_command {
+	struct cuse_dev *dev;
+	unsigned long fflags;
+	uintptr_t per_file_handle;
+	uintptr_t data_pointer;
+	unsigned long argument;
+	unsigned long command;		/* see CUSE_CMD_XXX */
+};
+
+struct cuse_create_dev {
+	struct cuse_dev *dev;
+	uid_t	user_id;
+	gid_t	group_id;
+	int	permissions;
+	char	devname[80];		/* /dev/xxxxx */
+};
+
+/* Definition of internal IOCTLs for /dev/cuse */
+
+#define	CUSE_IOCTL_GET_COMMAND		_IOR('C', 0, struct cuse_command)
+#define	CUSE_IOCTL_WRITE_DATA		_IOW('C', 1, struct cuse_data_chunk)
+#define	CUSE_IOCTL_READ_DATA		_IOW('C', 2, struct cuse_data_chunk)
+#define	CUSE_IOCTL_SYNC_COMMAND		_IOW('C', 3, int)
+#define	CUSE_IOCTL_GET_SIG		_IOR('C', 4, int)
+#define	CUSE_IOCTL_ALLOC_MEMORY		_IOW('C', 5, struct cuse_alloc_info)
+#define	CUSE_IOCTL_FREE_MEMORY		_IOW('C', 6, struct cuse_alloc_info)
+#define	CUSE_IOCTL_SET_PFH		_IOW('C', 7, uintptr_t)
+#define	CUSE_IOCTL_CREATE_DEV		_IOW('C', 8, struct cuse_create_dev)
+#define	CUSE_IOCTL_DESTROY_DEV		_IOW('C', 9, struct cuse_dev *)
+#define	CUSE_IOCTL_ALLOC_UNIT		_IOR('C',10, int)
+#define	CUSE_IOCTL_FREE_UNIT		_IOW('C',11, int)
+#define	CUSE_IOCTL_SELWAKEUP		_IOW('C',12, int)
+#define	CUSE_IOCTL_ALLOC_UNIT_BY_ID	_IOWR('C',13, int)
+#define	CUSE_IOCTL_FREE_UNIT_BY_ID	_IOWR('C',14, int)
+
+#endif			/* _CUSE_IOCTL_H_ */


### PR DESCRIPTION
These are the kernel bits that UHIDD depends on, UHIDD has been tested on qemu ands works using the USB keyboard and mouse that qemu emulates. This was originally inspired by the [code bounty report](https://www.dragonflybsd.org/docs/developer/Code_Bounties/#index7h2)  but wasn't reported beforehand, I understand `kerma` might not care about this anymore. I am aware this repo is read only, im a bit confused on where to submit this but I have to do my college work first.

The vkbd has been independently unit tested and the mouse has been tested using syscons but X hasn't been tested. Joypads haven't been tested.

The port of the UHIDD daemon is hosted on gitlab here: https://gitlab.com/YusufAbdulHalim/uhidd 