### PR TITLE
ext2: sync FreeBSD changes except large sectorsize disks support

### DIFF
--- a/sys/vfs/ext2fs/ext2_alloc.c
+++ b/sys/vfs/ext2fs/ext2_alloc.c
@@ -1048,7 +1048,7 @@ ext2_alloccg(struct inode *ip, int cg, daddr_t bpref, int size)
 		start = dtogd(fs, bpref) / NBBY;
 	else
 		start = 0;
-	end = howmany(fs->e2fs_fpg, NBBY) - start;
+	end = howmany(fs->e2fs_fpg, NBBY);
 retry:
 	runlen = 0;
 	runstart = 0;

--- a/sys/vfs/ext2fs/ext2_lookup.c
+++ b/sys/vfs/ext2fs/ext2_lookup.c
@@ -259,7 +259,7 @@ nextentry:
 		error = 0;
 	if (ap->a_ncookies != NULL) {
 		if (error == 0) {
-			ap->a_ncookies -= ncookies;
+			*ap->a_ncookies -= ncookies;
 		} else {
 			free(*ap->a_cookies, M_TEMP);
 			*ap->a_ncookies = 0;
@@ -532,8 +532,8 @@ found:
 	if (entryoffsetinblock + EXT2_DIR_REC_LEN(ep->e2d_namlen) >
 	    dp->i_size) {
 		ext2_dirbad(dp, i_offset, "i_size too small");
-		dp->i_size = entryoffsetinblock + EXT2_DIR_REC_LEN(ep->e2d_namlen);
-		dp->i_flag |= IN_CHANGE | IN_UPDATE;
+		brelse(bp);
+		return (EIO);
 	}
 	brelse(bp);
 
@@ -774,13 +774,9 @@ ext2_dirbad(struct inode *ip, doff_t offset, char *how)
 	struct mount *mp;
 
 	mp = ITOV(ip)->v_mount;
-	if ((mp->mnt_flag & MNT_RDONLY) == 0)
-		panic("ext2_dirbad: %s: bad dir ino %ju at offset %ld: %s\n",
-		    mp->mnt_stat.f_mntonname, (uintmax_t)ip->i_number,
-		    (long)offset, how);
-	else
-		SDT_PROBE4(ext2fs, , trace, ext2_dirbad_error,
-		    mp->mnt_stat.f_mntonname, ip->i_number, offset, how);
+
+	SDT_PROBE4(ext2fs, , trace, ext2_dirbad_error,
+	    mp->mnt_stat.f_mntonname, ip->i_number, offset, how);
 }
 
 /*
@@ -790,6 +786,8 @@ ext2_dirbad(struct inode *ip, doff_t offset, char *how)
  *	record must be large enough to contain entry
  *	name is not longer than MAXNAMLEN
  *	name must be as long as advertised, and null terminated
+ *	inode number less then inode count
+ *	if root inode entry, it have correct name
  */
 static int
 ext2_check_direntry(struct vnode *dp, struct ext2fs_direct_2 *de,
@@ -808,6 +806,11 @@ ext2_check_direntry(struct vnode *dp, struct ext2fs_direct_2 *de,
 		error_msg = "directory entry across blocks";
 	else if (le32toh(de->e2d_ino) > fs->e2fs->e2fs_icount)
 		error_msg = "directory entry inode out of bounds";
+	else if (le32toh(de->e2d_ino) == EXT2_ROOTINO &&
+	    ((de->e2d_namlen != 1 && de->e2d_namlen != 2) ||
+	    (de->e2d_name[0] != '.') ||
+	    (de->e2d_namlen == 2 && de->e2d_name[1] != '.')))
+		error_msg = "bad root directory entry";
 
 	if (error_msg != NULL) {
 		SDT_PROBE5(ext2fs, , trace, ext2_dirbadentry_error,

--- a/sys/vfs/ext2fs/ext2_vfsops.c
+++ b/sys/vfs/ext2fs/ext2_vfsops.c
@@ -1481,6 +1481,8 @@ ext2_vptofh(struct vnode *vp, struct fid *fhp)
 {
 	struct inode *ip;
 	struct ufid *ufhp;
+	_Static_assert(sizeof(struct ufid) <= sizeof(struct fid),
+		"struct ufid cannot be larger than struct fid");
 
 	ip = VTOI(vp);
 	ufhp = (struct ufid *)fhp;

--- a/sys/vfs/ext2fs/ext2_vnops.c
+++ b/sys/vfs/ext2fs/ext2_vnops.c
@@ -1049,6 +1049,15 @@ abortit:
 				if (namlen != 2 ||
 				    dirbuf->dotdot_name[0] != '.' ||
 				    dirbuf->dotdot_name[1] != '.') {
+					/*
+					 * The filesystem is in corrupted state,
+					 * need to run fsck to fix mangled dir
+					 * entry. From other side this error
+					 * need to be ignored because it is
+					 * too difficult to revert directories
+					 * to state before rename from this
+					 * point.
+					 */
 					ext2_dirbad(xp, (doff_t)12,
 					    "rename: mangled dir");
 				} else {

--- a/sys/vfs/ext2fs/inode.h
+++ b/sys/vfs/ext2fs/inode.h
@@ -189,10 +189,10 @@ struct indir {
 
 /* This overlays the fid structure (see mount.h). */
 struct ufid {
-	uint16_t ufid_len;		/* Length of structure. */
-	uint16_t ufid_pad;		/* Force 32-bit alignment. */
-	ino_t	ufid_ino;		/* File number (ino). */
-	uint32_t ufid_gen;		/* Generation number. */
+	uint16_t	ufid_len;	/* Length of structure. */
+	uint16_t	ufid_pad;	/* Force 32-bit alignment. */
+	uint32_t	ufid_gen;	/* Generation number. */
+	ino_t		ufid_ino;	/* File number (ino). */
 };
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
Patches synced in from FreeBSD:

ext2fs: 'struct ufid': Re-order fields and unpack
ext2fs: Fix the size of struct ufid and add a static assert Do not panic in case of corrupted directory
Add root directory entry check.
Fix block bitmap end position computation
Fix vop_readdir's ncookies handling in UFS and EXT2.

---

large sectorsize disks support can be synced in later, these are fixes so perhaps this should be synced with the 6.4 branch? Commits about ext2_extents wasn't included because we don't support it.