### PR TITLE
reboot: fix openlog(3) calls

### DIFF
--- a/sbin/reboot/reboot.c
+++ b/sbin/reboot/reboot.c
@@ -112,10 +112,10 @@ main(int argc, char *argv[])
 			user = (pw = getpwuid(getuid())) ?
 			    pw->pw_name : "???";
 		if (dohalt) {
-			openlog("halt", 0, LOG_AUTH | LOG_CONS);
+			openlog("halt", LOG_CONS, LOG_AUTH);
 			syslog(LOG_CRIT, "halted by %s", user);
 		} else {
-			openlog("reboot", 0, LOG_AUTH | LOG_CONS);
+			openlog("reboot", LOG_CONS, LOG_AUTH);
 			syslog(LOG_CRIT, "rebooted by %s", user);
 		}
 	}


### PR DESCRIPTION
LOG_CONS was OR'd into the facility argument instead of logopt, leaving logopt as 0.  The correct call is openlog(ident, LOG_CONS, LOG_AUTH), as shutdown(8) and init(8) already do.

Similar fix in https://github.com/freebsd/freebsd-src/pull/2300
