### PR TITLE
libthread_xu: link with -z nodelete; unloading it is unsafe

### DIFF
--- a/lib/libthread_xu/Makefile
+++ b/lib/libthread_xu/Makefile
@@ -31,6 +31,16 @@ CFLAGS+=-D_PTHREADS_DEBUGGING2
 .endif
 
 
+# libthread_xu cannot be safely unloaded.  Loading it has irreversible
+# process-wide effects: libc lazily binds its weak pthread/_spinlock
+# stubs to the strong definitions in this library, __isthreaded stays
+# set, and _thr_signal_init() installs signal handlers pointing into
+# this library.  After a dlclose() unmaps it, the next locked malloc
+# operation (or signal delivery) jumps through a dangling pointer and
+# crashes.  Mark the library DF_1_NODELETE so dlclose() never unmaps
+# it, mirroring FreeBSD libthr.
+LDFLAGS+=	-Wl,-znodelete
+
 PRECIOUSLIB=	yes
 
 LIBDIR=	/usr/lib/thread


### PR DESCRIPTION
## Problem

Any program that `dlopen()`s a dependency chain pulling in libthread_xu, creates a thread, and later `dlclose()`s the handle crashes with SIGSEGV on the next `free()`.

Real-world victim: `vulkaninfo` (graphics/vulkan-tools). It does not link against pthread itself and loads the Vulkan loader via `dlopen()`; Mesa ICDs depend on libpthread. On DragonFly it exits 139 on every run, and the report it generates is usually lost because stdio buffers are never flushed:

```
#0  0x0000000801061e9b in ?? ()        <- _spinlock+0 inside the unmapped libthread_xu
#1  0x0000000800d5b315 in ?? () from /lib/libc.so.8
#2  0x0000000800d5dbb3 in free () from /lib/libc.so.8
#3  0x00000008007defe9 in operator delete(void*) ()
#4  0x000000000049539e in AppInstance::~AppInstance() ()
#5  0x000000000041caed in main ()
```

## Root cause

Loading libthread_xu mutates process-wide state that `dlclose()` cannot undo:

1. **GOT bindings.** libc defines `_spinlock` as a weak no-op stub (`lib/libc/gen/_spinlock_stub.c`), and every `_SPINLOCK()` in nmalloc is guarded by `if (__isthreaded)` — so the symbol is first called (and lazily bound) only after libthread_xu is loaded and a thread exists. rtld prefers the strong definition in libthread_xu and patches libc GOT permanently. Nothing rebinds it on unload.
2. **`__isthreaded` stays set.** `_libpthread_uninit()` only releases the main-thread red zone and the stack cache; it cannot safely clear `__isthreaded` because it cannot prove no other threads exist. libc malloc therefore keeps taking the locked path through the now-dangling pointer.
3. **Signal handlers.** `_thr_signal_init()` installs handlers pointing into the library; `_thr_signal_deinit()` is an empty function, so delivery after unload also jumps into unmapped memory.

## Fix

Mark the DSO `DF_1_NODELETE`, exactly as FreeBSD did for libthr in 2009 — freebsd/freebsd-src@35c608253dd2 by David Xu, the original author of this library: *"Turn on nodelete linker flag because libthr can not be unloaded safely, it does hook on to libc."*

rtld-elf already honors the flag; verified that it protects both a direct `dlopen()` of the library and unloads via a dependency chain.

## Reproduction

```c
#include <dlfcn.h>
#include <stdio.h>
#include <stdlib.h>
static void *body(void *a) { return a; }
int main(void) {
    void *h = dlopen("/usr/lib/libpthread.so.0", RTLD_NOW | RTLD_GLOBAL);
    int (*create)(void *, const void *, void *(*)(void *), void *) =
        dlsym(h, "pthread_create");
    int (*join)(void *, void **) = dlsym(h, "pthread_join");
    void *t = NULL, *r;
    create(&t, NULL, body, NULL);
    join(t, &r);
    free(malloc(4096));
    dlclose(h);
    free(malloc(4096));    /* SIGSEGV here */
    printf("survived\n");
    return 0;
}
```

Before: `Segmentation fault (core dumped)`, exit 139.
After: prints `survived`, exit 0.

Also verified on a real system (6.5-DEVELOPMENT, Mesa NVK): `vulkaninfo --summary` goes from exit 139 to exit 0, `readelf -d libthread_xu.so.2` shows `FLAGS_1: NODELETE`, and threaded programs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
