### PR TITLE
if_tun: mbuf chain leak in tunwrite on unsupported address family

### DIFF
--- a/sys/net/tun/if_tun.c
+++ b/sys/net/tun/if_tun.c
@@ -950,7 +950,7 @@ tunwrite(struct dev_write_args *ap)
 		break;
 #endif
 	default:
-		m_freem(m);
+		m_freem(top);
 		return (EAFNOSUPPORT);
 	}
 


### PR DESCRIPTION
# if_tun: mbuf chain leak in tunwrite on unsupported address family

`tunwrite()` assembles an mbuf chain headed by `top` in its `uiomove` loop (sys/net/tun/if_tun.c:875). On the final loop iteration the conditional `MGET` at :880 is not taken, so the local `m` ends up pointing at the chain tail (`m_next == NULL`) while `top` still holds the head. When `TUN_IFHEAD` is set and the user-supplied 4-byte address family is neither `AF_INET` nor `AF_INET6`, the `default` case of the family switch at :953 calls `m_freem(m)`. `m_freem()` walks `m_next` starting from its argument, so this frees only the single trailing mbuf and leaks the chain head `top` plus every intermediate mbuf — up to ~326 mbufs per max-size write (`TUNMRU + 4`). The leak is unbounded and fully repeatable, exhausting kernel mbuf memory system-wide until the network stack wedges for every process and jail on the host.

## Fix

Free the chain head `top` in the `default` case instead of the tail `m`, matching the earlier error path at :885 which already calls `m_freem(top)`. `top` is the chain head set at :873/:878 and is the argument `m_freem` needs to walk the whole chain.

## Before / after

`netstat -m`, mbufs in use, same PoC workload on each kernel:

#0 unpatched (DragonFly 6.5-DEVELOPMENT #0):

```
baseline:            7
after 50 writes:     13207   (+13200, ~264 leaked/write)
after 100 more:      39607   (+26400, monotonic / unreclaimed)
```

#1 patched (DragonFly 6.5-DEVELOPMENT #1, this change only):

```
RUN A  50 writes:    7 -> 7   (delta 0)
RUN B  50 writes:    7 -> 7   (delta 0)
RUN C  200 writes:   7 -> 7   (delta 0)
```

## Reproducer

Open the tun clone device, enable `TUN_IFHEAD`, and repeatedly write a max-size buffer whose 4-byte family prefix is neither `AF_INET` nor `AF_INET6`. Each write returns `EAFNOSUPPORT` after leaking the chain; watch `netstat -m` climb on an unpatched kernel. `/dev/tun` open requires `SYSCAP_RESTRICTEDROOT` (host root).

```c
/* tun_leak.c - leak the mbuf chain in tunwrite's EAFNOSUPPORT path */
#include <sys/types.h>
#include <sys/ioctl.h>
#include <fcntl.h>
#include <unistd.h>
#include <string.h>
#include <stdio.h>
#include <errno.h>
#include <stdlib.h>

#define TUNMRU     65535
#define TUNSIFHEAD _IOW('t', 96, int)   /* sys/net/tun/if_tun.h */

static unsigned char buf[TUNMRU + 4];   /* +4 for the IFHEAD family prefix */

int
main(int argc, char **argv)
{
	unsigned long n = (argc > 1) ? strtoul(argv[1], NULL, 10) : 50;
	unsigned long i;
	int fd, one = 1;
	ssize_t s;

	fd = open("/dev/tun", O_RDWR);
	if (fd < 0) { perror("open /dev/tun"); return 2; }
	if (ioctl(fd, TUNSIFHEAD, &one) < 0) { perror("TUNSIFHEAD"); return 2; }

	/* 4-byte family != AF_INET/AF_INET6 hits the default case */
	memset(buf, 0x41, sizeof(buf));
	buf[0] = buf[1] = buf[2] = buf[3] = 0xff;

	for (i = 0; i < n; i++) {
		s = write(fd, buf, sizeof(buf));
		if (s < 0 && (errno == ENOBUFS || errno == ENOMEM))
			break;		/* mbuf zone exhausted */
	}
	close(fd);
	return 0;
}
```

Build and run:

```
cc -O2 -o tun_leak tun_leak.c
./tun_leak 50        # as host root; in another shell, watch `netstat -m`
```
