### PR TITLE
nmalloc: make the allocator self-contained; drop the pthread stubs

### DIFF
--- a/lib/libc/gen/_thread_init.c
+++ b/lib/libc/gen/_thread_init.c
@@ -31,6 +31,7 @@
 
 void	_thread_init_stub(void);
 void	_nmalloc_thr_init(void);
+void	_nmalloc_thr_exit(void);
 void	_upmap_thr_init(void);
 
 int	_thread_autoinit_dummy_decl_stub = 0;
@@ -66,6 +67,16 @@ _libc_thr_init(void)
 {
 	_nmalloc_thr_init();
 	_upmap_thr_init();
+}
+
+/*
+ * Per-thread teardown, called by pthreads when a thread exits, after
+ * the application's TSD destructors have run.
+ */
+void
+_libc_thr_exit(void)
+{
+	_nmalloc_thr_exit();
 }
 
 __weak_reference(_thread_autoinit_dummy_decl_stub, _thread_autoinit_dummy_decl);

--- a/lib/libc/include/libc_private.h
+++ b/lib/libc/include/libc_private.h
@@ -114,7 +114,9 @@ extern void (*__cleanup)(void);
 /* execve() with PATH processing to implement posix_spawnp() */
 int _execvpe(const char *, char * const *, char * const *);
 void _libc_thr_init(void);
+void _libc_thr_exit(void);
 void _nmalloc_thr_init(void);
+void _nmalloc_thr_exit(void);
 void _upmap_thr_init(void);
 void _nmalloc_thr_prepfork(void);
 void _nmalloc_thr_parentfork(void);

--- a/lib/libc/stdlib/Symbol.map
+++ b/lib/libc/stdlib/Symbol.map
@@ -147,4 +147,5 @@ DF604.0 {
 DFprivate_1.0 {
     __cleanup;
     __system;
+    _libc_thr_exit;
 };

--- a/lib/libc/stdlib/dmalloc.c
+++ b/lib/libc/stdlib/dmalloc.c
@@ -446,6 +446,15 @@ _nmalloc_thr_init(void)
 	slglobal.masked = 0;
 }
 
+/*
+ * dmalloc reclaims its per-thread state via the TSD destructor installed
+ * by _nmalloc_thr_init(); nothing to do at direct thread-exit time.
+ */
+void
+_nmalloc_thr_exit(void)
+{
+}
+
 void
 _nmalloc_thr_prepfork(void)
 {

--- a/lib/libc/stdlib/nmalloc.c
+++ b/lib/libc/stdlib/nmalloc.c
@@ -126,12 +126,75 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <pthread.h>
 #include <machine/atomic.h>
+#include <machine/cpufunc.h>
 #include "un-namespace.h"
 
 #include "libc_private.h"
-#include "spinlock.h"
+
+/*
+ * Self-contained locks.
+ *
+ * malloc must not depend on the pthread spinlock API (_SPINLOCK et al).
+ * Those are weak stubs which rtld rebinds to the strong definitions
+ * inside the thread library once one is loaded.  If the thread library
+ * is later unmapped by a dlclose(), libc's GOT entries keep pointing
+ * into the unmapped object and the next locked malloc operation jumps
+ * through a dangling pointer.  Implement locking directly on top of
+ * umtx_sleep()/umtx_wakeup() instead, so the allocator never leaves
+ * libc.
+ *
+ * Lock word states: 0 unlocked, 1 locked, 2 locked with waiter(s).
+ * The uncontended paths are a single locked cmpxchg.
+ */
+typedef volatile u_int nmalloc_lock_t;
+
+#define NMALLOC_LOCK_SPIN	200	/* pause iterations before sleeping */
+
+static void
+nmalloc_lock_contended(nmalloc_lock_t *lk)
+{
+	int spin = NMALLOC_LOCK_SPIN;
+	u_int v;
+
+	for (;;) {
+		v = *lk;
+		if (v == 0) {
+			/*
+			 * Acquire in contended state so the unlocker
+			 * knows to issue a wakeup for any other waiter.
+			 */
+			if (atomic_cmpset_int(lk, 0, 2))
+				return;
+			continue;
+		}
+		if (spin > 0) {
+			--spin;
+			cpu_pause();
+			continue;
+		}
+		if (v == 1 && !atomic_cmpset_int(lk, 1, 2))
+			continue;
+		umtx_sleep((volatile const int *)lk, 2, 0);
+	}
+}
+
+static __inline void
+nmalloc_lock(nmalloc_lock_t *lk)
+{
+	if (__predict_false(!atomic_cmpset_int(lk, 0, 1)))
+		nmalloc_lock_contended(lk);
+}
+
+static __inline void
+nmalloc_unlock(nmalloc_lock_t *lk)
+{
+	if (__predict_false(!atomic_cmpset_int(lk, 1, 0))) {
+		/* was contended (2); release and wake one waiter */
+		atomic_store_rel_int(lk, 0);
+		umtx_wakeup((volatile const int *)lk, 1);
+	}
+}
 
 void __free(void *);
 void *__malloc(size_t);
@@ -196,7 +259,7 @@ typedef struct slzone {
 } *slzone_t;
 
 typedef struct slglobaldata {
-	spinlock_t	Spinlock;
+	nmalloc_lock_t	Spinlock;
 	slzone_t	ZoneAry[NZONES];/* linked list of zones NFree > 0 */
 } *slglobaldata_t;
 
@@ -213,10 +276,6 @@ typedef struct slglobaldata {
 #define MIN_CHUNK_MASK		(MIN_CHUNK_SIZE - 1)
 #define IN_SAME_PAGE_MASK	(~(intptr_t)PAGE_MASK | MIN_CHUNK_MASK)
 
-/*
- * WARNING: A limited number of spinlocks are available, BIGXSIZE should
- *	    not be larger then 64.
- */
 #define BIGHSHIFT	10			/* bigalloc hash table */
 #define BIGHSIZE	(1 << BIGHSHIFT)
 #define BIGHMASK	(BIGHSIZE - 1)
@@ -289,8 +348,8 @@ struct magazine {
 
 SLIST_HEAD(magazinelist, magazine);
 
-static spinlock_t zone_mag_lock;
-static spinlock_t depot_spinlock;
+static nmalloc_lock_t zone_mag_lock;
+static nmalloc_lock_t depot_spinlock;
 static struct magazine zone_magazine = {
 	.flags = 0,
 	.capacity = M_ZONE_INIT_ROUNDS,
@@ -316,7 +375,7 @@ typedef struct magazine_pair {
 typedef struct magazine_depot {
 	struct magazinelist full;
 	struct magazinelist empty;
-	spinlock_t	lock;
+	nmalloc_lock_t	lock;
 } magazine_depot;
 
 typedef struct thr_mags {
@@ -326,8 +385,6 @@ typedef struct thr_mags {
 } thr_mags;
 
 static __thread thr_mags thread_mags TLS_ATTRIBUTE;
-static pthread_key_t thread_mags_key;
-static pthread_once_t thread_mags_once = PTHREAD_ONCE_INIT;
 static magazine_depot depots[NZONES];
 
 /*
@@ -343,7 +400,7 @@ static int opt_utrace = 0;
 static int g_malloc_flags = 0;
 static struct slglobaldata SLGlobalData;
 static bigalloc_t bigalloc_array[BIGHSIZE];
-static spinlock_t bigspin_array[BIGXSIZE];
+static nmalloc_lock_t bigspin_array[BIGXSIZE];
 static volatile void *bigcache_array[BIGCACHE];		/* atomic swap */
 static volatile size_t bigcache_size_array[BIGCACHE];	/* SMP races ok */
 static volatile int bigcache_index;			/* SMP races ok */
@@ -361,7 +418,6 @@ static void *magazine_alloc(struct magazine *);
 static int magazine_free(struct magazine *, void *);
 static void *mtmagazine_alloc(int zi, int flags);
 static int mtmagazine_free(int zi, void *);
-static void mtmagazine_init(void);
 static void mtmagazine_destructor(void *);
 static slzone_t zone_alloc(int flags);
 static void zone_free(void *z);
@@ -409,36 +465,32 @@ malloc_init(void)
 }
 
 /*
- * We have to install a handler for nmalloc thread teardowns when
- * the thread is created.  We cannot delay this because destructors in
- * sophisticated userland programs can call malloc() for the first time
- * during their thread exit.
- *
- * This routine is called directly from pthreads.
+ * Thread setup/teardown hooks, called directly from pthreads on thread
+ * creation and exit.  These are direct calls rather than TSD destructors
+ * so that the allocator does not depend on the pthread TSD machinery
+ * (nmalloc must stay self-contained; see the lock comments above), and
+ * so that teardown ordering relative to application TSD destructors is
+ * explicit: pthreads runs the application's destructors first, then
+ * calls _nmalloc_thr_exit().
  */
 void
 _nmalloc_thr_init(void)
 {
-	thr_mags *tp;
+	thread_mags.init = 1;
+}
 
-	/*
-	 * Disallow mtmagazine operations until the mtmagazine is
-	 * initialized.
-	 */
-	tp = &thread_mags;
-	tp->init = -1;
-
-	_pthread_once(&thread_mags_once, mtmagazine_init);
-	_pthread_setspecific(thread_mags_key, tp);
-	tp->init = 1;
+void
+_nmalloc_thr_exit(void)
+{
+	mtmagazine_destructor(&thread_mags);
 }
 
 void
 _nmalloc_thr_prepfork(void)
 {
 	if (__isthreaded) {
-		_SPINLOCK(&zone_mag_lock);
-		_SPINLOCK(&depot_spinlock);
+		nmalloc_lock(&zone_mag_lock);
+		nmalloc_lock(&depot_spinlock);
 	}
 }
 
@@ -446,8 +498,8 @@ void
 _nmalloc_thr_parentfork(void)
 {
 	if (__isthreaded) {
-		_SPINUNLOCK(&depot_spinlock);
-		_SPINUNLOCK(&zone_mag_lock);
+		nmalloc_unlock(&depot_spinlock);
+		nmalloc_unlock(&zone_mag_lock);
 	}
 }
 
@@ -455,8 +507,8 @@ void
 _nmalloc_thr_childfork(void)
 {
 	if (__isthreaded) {
-		_SPINUNLOCK(&depot_spinlock);
-		_SPINUNLOCK(&zone_mag_lock);
+		nmalloc_unlock(&depot_spinlock);
+		nmalloc_unlock(&zone_mag_lock);
 	}
 }
 
@@ -489,42 +541,42 @@ static __inline void
 slgd_lock(slglobaldata_t slgd)
 {
 	if (__isthreaded)
-		_SPINLOCK(&slgd->Spinlock);
+		nmalloc_lock(&slgd->Spinlock);
 }
 
 static __inline void
 slgd_unlock(slglobaldata_t slgd)
 {
 	if (__isthreaded)
-		_SPINUNLOCK(&slgd->Spinlock);
+		nmalloc_unlock(&slgd->Spinlock);
 }
 
 static __inline void
 depot_lock(magazine_depot *dp __unused)
 {
 	if (__isthreaded)
-		_SPINLOCK(&depot_spinlock);
+		nmalloc_lock(&depot_spinlock);
 }
 
 static __inline void
 depot_unlock(magazine_depot *dp __unused)
 {
 	if (__isthreaded)
-		_SPINUNLOCK(&depot_spinlock);
+		nmalloc_unlock(&depot_spinlock);
 }
 
 static __inline void
 zone_magazine_lock(void)
 {
 	if (__isthreaded)
-		_SPINLOCK(&zone_mag_lock);
+		nmalloc_lock(&zone_mag_lock);
 }
 
 static __inline void
 zone_magazine_unlock(void)
 {
 	if (__isthreaded)
-		_SPINUNLOCK(&zone_mag_lock);
+		nmalloc_unlock(&zone_mag_lock);
 }
 
 static __inline void
@@ -564,7 +616,7 @@ bigalloc_lock(void *ptr)
 
 	bigp = &bigalloc_array[hv & BIGHMASK];
 	if (__isthreaded)
-		_SPINLOCK(&bigspin_array[hv & BIGXMASK]);
+		nmalloc_lock(&bigspin_array[hv & BIGXMASK]);
 	return(bigp);
 }
 
@@ -585,7 +637,7 @@ bigalloc_check_and_lock(const void *ptr)
 	if (*bigp == NULL)
 		return(NULL);
 	if (__isthreaded) {
-		_SPINLOCK(&bigspin_array[hv & BIGXMASK]);
+		nmalloc_lock(&bigspin_array[hv & BIGXMASK]);
 	}
 	return(bigp);
 }
@@ -597,7 +649,7 @@ bigalloc_unlock(const void *ptr)
 
 	if (__isthreaded) {
 		hv = _bigalloc_hash(ptr);
-		_SPINUNLOCK(&bigspin_array[hv & BIGXMASK]);
+		nmalloc_unlock(&bigspin_array[hv & BIGXMASK]);
 	}
 }
 
@@ -671,13 +723,13 @@ handle_excess_big(void)
 		if (*bigp == NULL)
 			continue;
 		if (__isthreaded)
-			_SPINLOCK(&bigspin_array[i & BIGXMASK]);
+			nmalloc_lock(&bigspin_array[i & BIGXMASK]);
 		for (big = *bigp; big; big = big->next) {
 			if (big->active < big->bytes) {
 				MASSERT_WTHUNLK((big->active & PAGE_MASK) == 0,
-				    _SPINUNLOCK(&bigspin_array[i & BIGXMASK]));
+				    nmalloc_unlock(&bigspin_array[i & BIGXMASK]));
 				MASSERT_WTHUNLK((big->bytes & PAGE_MASK) == 0,
-				    _SPINUNLOCK(&bigspin_array[i & BIGXMASK]));
+				    nmalloc_unlock(&bigspin_array[i & BIGXMASK]));
 				munmap((char *)big->base + big->active,
 				       big->bytes - big->active);
 				atomic_add_long(&excess_alloc,
@@ -686,7 +738,7 @@ handle_excess_big(void)
 			}
 		}
 		if (__isthreaded)
-			_SPINUNLOCK(&bigspin_array[i & BIGXMASK]);
+			nmalloc_unlock(&bigspin_array[i & BIGXMASK]);
 	}
 }
 
@@ -1929,13 +1981,6 @@ mtmagazine_free(int zi, void *ptr)
 	return rc;
 }
 
-static void
-mtmagazine_init(void)
-{
-	/* ignore error from stub if not threaded */
-	_pthread_key_create(&thread_mags_key, mtmagazine_destructor);
-}
-
 /*
  * This function is only used by the thread exit destructor
  */
@@ -1955,12 +2000,13 @@ mtmagazine_drain(struct magazine *mp)
 /*
  * mtmagazine_destructor()
  *
- * When a thread exits, we reclaim all its resources; all its magazines are
- * drained and the structures are freed.
+ * Called via _nmalloc_thr_exit() when a thread exits; all of the thread's
+ * magazines are drained and the structures are freed.
  *
- * WARNING!  The destructor can be called multiple times if the larger user
- *	     program has its own destructors which run after ours which
- *	     allocate or free memory.
+ * WARNING!  Allocations can still occur after this runs (for example from
+ *	     the threading library's own teardown), so tp->init is set to
+ *	     -1 to make later malloc/free operations bypass the (destroyed)
+ *	     magazine layer.
  */
 static void
 mtmagazine_destructor(void *thrp)

--- a/lib/libthread_xu/thread/thr_exit.c
+++ b/lib/libthread_xu/thread/thr_exit.c
@@ -137,6 +137,9 @@ exit_thread(void)
 		_thread_cleanupspecific();
 	}
 
+	/* Return this thread's allocator caches (magazines) to libc. */
+	_libc_thr_exit();
+
 	if (!_thr_isthreaded())
 		exit(0);
 


### PR DESCRIPTION
## Problem

malloc must not depend on a library that `dlclose()` can unmap — but it currently does.

nmalloc takes its locks through the libc spinlock stubs (`_SPINLOCK` et al) and registers its per-thread magazine cleanup via `_pthread_key_create()`. Both are weak stubs that rtld rebinds to the strong definitions inside libthread_xu the moment a thread library is loaded. If the thread library is later unmapped by `dlclose()` (e.g. a program that `dlopen()`s a plugin chain pulling in libpthread — the Vulkan loader/Mesa ICD case from #38), `__isthreaded` remains set and the next locked malloc operation jumps through libc's dangling GOT entry into unmapped memory: instant SIGSEGV in `free()`.

#38 addresses this at the system level by making libthread_xu `DF_1_NODELETE` (unloading a thread library is never safe). This PR is the complementary allocator-side fix: malloc itself stops depending on any unloadable library, which is also the first concrete step toward folding the thread library into libc.

## Change

**Locks.** Replace the spinlock stubs with a self-contained adaptive lock built on `atomic_cmpset_int()` + `umtx_sleep()`/`umtx_wakeup()`. Lock word states: 0 unlocked, 1 locked, 2 locked-with-waiters. Uncontended paths are a single locked cmpxchg; contention does a bounded `cpu_pause()` spin (200 iterations) and then sleeps in the kernel. The single-threaded fast paths (`__isthreaded == 0`) are untouched, so non-threaded processes see identical code. The threaded paths lose a PLT indirection, a `tls_get_curthread()` and libthread_xu's spinlock registration checks.

**Per-thread teardown.** Replace the TSD destructor with an explicit pairing: pthreads already calls `_libc_thr_init()` for every new thread; this adds `_libc_thr_exit()` (DFprivate_1.0), called from thread exit *after* the application's TSD destructors have run, returning the thread's magazines to the depot. This removes the last pthread dependency from nmalloc and makes the previously unspecified ordering between magazine cleanup and application TSD destructors explicit. `nm -u nmalloc.o` now shows no pthread/spinlock references — only the two umtx syscalls.

dmalloc (currently disabled in the build) gets a matching no-op `_nmalloc_thr_exit()` so it stays linkable.

## Tests

All run as A/B against stock libc via `LD_LIBRARY_PATH`, on a 32-CPU box:

1. **dlclose-dangling reproducer** — dlopen a (non-NODELETE) libthread_xu by path, create+join a thread, dlclose, then 100k mixed malloc/free including the bigalloc path. Stock libc: SIGSEGV on the first locked free. Patched libc: survives. (The process must still `_exit()`; `exit(3)` would run the stdio cleanup whose locks are still stub-based — that is the next dangling surface, out of scope here.)
2. **16-thread pattern-verifying stress, 10s** — randomized alloc/realloc/free across 20 size classes spanning all slab zones and bigalloc, every byte pattern-checked on free, plus a locked exchange table forcing cross-thread frees through the depot. Passes on both.
3. **fork-under-allocation stress** — 8 threads churning the allocator while the main thread forks 100 children; every child mallocs immediately (exercises the prepfork/childfork lock handoff with the new locks). Passes on both.
4. **2200-thread churn / reclamation check** — short-lived threads populating magazines across all zones. RSS growth after warmup: **1368 KB (stock) -> 284 KB (patched)** — the explicit exit hook reclaims per-thread state more reliably than the TSD destructor did.
5. **Smoke** — python3 (threaded), git status on a large repo, cc compile+run, all under the patched libc.

## Benchmarks

Median of 5, `LD_LIBRARY_PATH` A/B, 32-CPU box. Sizes span magazine and bigalloc paths; "cross-thread free" is a producer/consumer ring where thread i allocates and thread i+1 frees (maximum depot pressure).

| benchmark | stock | patched | delta |
|---|---|---|---|
| ST malloc/free 64B | 19.42 ns/op | 19.47 ns/op | parity |
| ST malloc/free 4KB | 19.21 ns/op | 19.69 ns/op | parity |
| ST batch-128 64B | 19.76 ns/op | 19.84 ns/op | parity |
| ST bigalloc 100KB | 34.15 ns/op | 33.69 ns/op | parity |
| 1T mixed local churn | 29.67 Mops/s | 29.84 Mops/s | parity |
| 4T mixed local churn | 108.4 Mops/s | 106.1 Mops/s | parity |
| 16T mixed local churn | 420.7 Mops/s | 424.0 Mops/s | parity |
| 32T mixed local churn | 596.2 Mops/s | 597.1 Mops/s | parity |
| 4T cross-thread free | 87.1 Mops/s | 96.7 Mops/s | **+11.1%** |
| 16T cross-thread free | 318.2 Mops/s | 320.0 Mops/s | +0.6% |
| 32T cross-thread free | 421.2 Mops/s | 441.2 Mops/s | **+4.7%** |

Single-threaded and thread-local paths are unchanged by design (within noise); the depot-heavy paths gain from the leaner lock.

## Compatibility notes

- `_libc_thr_exit` is exported under `DFprivate_1.0` — a private libc/libthread_xu contract, no public ABI surface.
- A new libc paired with an old libthread_xu does not reclaim per-thread magazines on thread exit (bounded leak, no crash); the two libraries ship together in base.
- `__isthreaded` semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
