### PR TITLE
vm: fix cdev pager object lifecycle

### DIFF
--- a/sys/vm/device_pager.c
+++ b/sys/vm/device_pager.c
@@ -98,8 +98,16 @@ cdev_pager_lookup(void *handle)
 {
 	vm_object_t object;
 
+again:
 	mtx_lock(&dev_pager_mtx);
 	object = vm_pager_object_lookup(&dev_pager_object_list, handle);
+	if (object != NULL && object->un_pager.devp.ops == NULL) {
+		mtxsleep(&object->un_pager.devp.ops, &dev_pager_mtx, 0,
+		    "cdplkp", 0);
+		mtx_unlock(&dev_pager_mtx);
+		vm_object_deallocate(object);
+		goto again;
+	}
 	mtx_unlock(&dev_pager_mtx);
 
 	return (object);
@@ -110,8 +118,10 @@ cdev_pager_allocate(void *handle, enum obj_type tp, struct cdev_pager_ops *ops,
 	vm_ooffset_t size, vm_prot_t prot, vm_ooffset_t foff, struct ucred *cred)
 {
 	cdev_t dev;
-	vm_object_t object;
+	vm_object_t object, object1;
+	vm_pindex_t pindex;
 	u_short color;
+	int error;
 
 	/*
 	 * Offset should be page aligned.
@@ -120,48 +130,76 @@ cdev_pager_allocate(void *handle, enum obj_type tp, struct cdev_pager_ops *ops,
 		return (NULL);
 
 	size = round_page64(size);
-
-	if (ops->cdev_pg_ctor(handle, size, prot, foff, cred, &color) != 0)
-		return (NULL);
+	pindex = OFF_TO_IDX(foff + size);
 
 	/*
 	 * Look up pager, creating as necessary.
 	 */
+again:
 	mtx_lock(&dev_pager_mtx);
 	object = vm_pager_object_lookup(&dev_pager_object_list, handle);
-	if (object == NULL) {
-		/*
-		 * Allocate object and associate it with the pager.
-		 */
-		object = vm_object_allocate_hold(tp,
-						 OFF_TO_IDX(foff + size));
-		object->handle = handle;
-		object->un_pager.devp.ops = ops;
-		object->un_pager.devp.dev = handle;
-		TAILQ_INIT(&object->un_pager.devp.devp_pglist);
-
-		/*
-		 * handle is only a device for old_dev_pager_ctor.
-		 */
-		if (ops->cdev_pg_ctor == old_dev_pager_ctor) {
-			dev = handle;
-			dev->si_object = object;
+	if (object != NULL) {
+		if (object->un_pager.devp.ops == NULL) {
+			mtxsleep(&object->un_pager.devp.ops, &dev_pager_mtx, 0,
+			    "cdplkp", 0);
+			mtx_unlock(&dev_pager_mtx);
+			vm_object_deallocate(object);
+			goto again;
 		}
-
-		TAILQ_INSERT_TAIL(&dev_pager_object_list, object,
-				  pager_object_entry);
-
-		vm_object_drop(object);
-	} else {
-		/*
-		 * Gain a reference to the object.
-		 */
 		vm_object_hold(object);
-		vm_object_reference_locked(object);
-		if (OFF_TO_IDX(foff + size) > object->size)
-			object->size = OFF_TO_IDX(foff + size);
+		if (pindex > object->size)
+			object->size = pindex;
+		KKASSERT(object->type == tp);
+		KKASSERT(object->un_pager.devp.ops == ops);
 		vm_object_drop(object);
+		mtx_unlock(&dev_pager_mtx);
+		return (object);
 	}
+	mtx_unlock(&dev_pager_mtx);
+
+	object1 = vm_object_allocate_hold(tp, pindex);
+
+	mtx_lock(&dev_pager_mtx);
+	object = vm_pager_object_lookup(&dev_pager_object_list, handle);
+	if (object != NULL) {
+		object1->type = OBJT_DEAD;
+		vm_object_drop(object1);
+		mtx_unlock(&dev_pager_mtx);
+		vm_object_deallocate(object1);
+		vm_object_deallocate(object);
+		goto again;
+	}
+
+	object = object1;
+	object->handle = handle;
+	object->un_pager.devp.dev = handle;
+	object->un_pager.devp.ops = NULL;
+	TAILQ_INIT(&object->un_pager.devp.devp_pglist);
+	TAILQ_INSERT_TAIL(&dev_pager_object_list, object, pager_object_entry);
+	vm_object_drop(object);
+	mtx_unlock(&dev_pager_mtx);
+
+	error = ops->cdev_pg_ctor(handle, size, prot, foff, cred, &color);
+	mtx_lock(&dev_pager_mtx);
+	if (error != 0) {
+		TAILQ_REMOVE(&dev_pager_object_list, object, pager_object_entry);
+		vm_object_hold(object);
+		object->type = OBJT_DEAD;
+		vm_object_drop(object);
+		wakeup(&object->un_pager.devp.ops);
+		mtx_unlock(&dev_pager_mtx);
+		vm_object_deallocate(object);
+		return (NULL);
+	}
+
+	vm_object_hold(object);
+	object->un_pager.devp.ops = ops;
+	if (ops->cdev_pg_ctor == old_dev_pager_ctor) {
+		dev = handle;
+		dev->si_object = object;
+	}
+	vm_object_drop(object);
+	wakeup(&object->un_pager.devp.ops);
 	mtx_unlock(&dev_pager_mtx);
 
 	return (object);


### PR DESCRIPTION
## Problem

`vm_pager_object_lookup()` returns an already-referenced `vm_object`.
`cdev_pager_allocate()` took another reference in its existing-object path, so
every repeated `mmap()` of the same pager handle leaked one object reference.
After all mappings were removed, the object could not reach
`dev_pager_dealloc()`: the pager destructor did not run and the owning driver
module remained busy.

There was a second lifecycle mismatch.  `cdev_pg_ctor` ran before the pager
object lookup, so it ran once per allocation request even though the handle was
deduplicated to one `vm_object`.  A non-idempotent constructor could therefore
run multiple times while `cdev_pg_dtor` ran only once.

## Trigger and failure mechanism

Any cdev pager consumer that maps the same pager handle more than once can
trigger the bug.  Two mappings are sufficient:

1. The first `cdev_pager_allocate()` creates the `vm_object`; its reference is
   transferred to the first mapping.
2. The second call finds that object.  `vm_pager_object_lookup()` acquires the
   reference needed by the second mapping.
3. The existing-object path then calls `vm_object_reference_locked()` and
   acquires another reference with no owner.
4. Removing both mappings releases their two references, but the unowned third
   reference remains.  The object cannot be deallocated, so `cdev_pg_dtor` is
   not called.

The constructor mismatch follows from the same two calls.  Both enter
`cdev_pg_ctor` before object lookup, but the handle lookup deduplicates them to
one `vm_object`.  The constructor therefore runs twice for an object that can
have at most one destructor call.

## Fix

* Return the reference acquired by `vm_pager_object_lookup()` directly instead
  of taking another reference.
* Allocate a candidate object outside `dev_pager_mtx`, then resolve allocation
  races after reacquiring the mutex.
* Insert the winning object with `ops == NULL` while its constructor runs
  outside the mutex.  Concurrent lookup and allocation callers wait for that
  construction to finish.
* On success, publish `ops` and wake the waiters.  On failure, remove the object
  from the pager list, mark it dead, wake the waiters, and release it.

FreeBSD uses `dev == NULL` as the construction sentinel.  DragonFly has valid
NULL-handle pager users, so this adaptation uses `ops == NULL` instead.

## FreeBSD precedent

This change adapts two FreeBSD fixes to DragonFly's locking and `vm_object`
lifetime rules:

* [df2f557df667](https://github.com/freebsd/freebsd-src/commit/df2f557df66756617fed295039d0ddca9be360a1): remove the duplicate reference
  after `vm_pager_object_lookup()`.
* [e93404065177](https://github.com/freebsd/freebsd-src/commit/e93404065177d6c909cd64bf7d74fe0d8df35edf): call the cdev pager constructor
  once per allocated `vm_object` and serialize concurrent construction
  ([FreeBSD PR 278826](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=278826),
  [review D45113](https://reviews.freebsd.org/D45113)).

## Expected behavior

* Repeated mappings of one handle share one `vm_object`, with exactly one
  caller-owned reference returned by each lookup.  Releasing the final mapping
  allows the object to reach `dev_pager_dealloc()`.
* `cdev_pg_ctor` runs exactly once for each allocated `vm_object`, regardless
  of how many callers race to allocate the same handle.  The matching
  `cdev_pg_dtor` runs once when that object is finally released.
* Concurrent callers never observe a partially constructed object.  They wait
  until the constructor publishes the pager operations, then reuse the same
  object.
* If construction fails, the unpublished object is removed and marked dead
  before waiters are awakened.  No destructor is called for the failed
  construction, and another caller can retry cleanly.
* Once all mappings and other external references are gone, no pager reference
  remains to keep the object or its owning driver module busy.
