### PR TITLE
kernel/linker: preserve refs after unload veto

### DIFF
--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -111,7 +111,7 @@ linker_basename(const char *path)
 static void
 linker_init(void* arg)
 {
-    lockinit(&llf_lock, "klink", 0, 0);
+    lockinit(&llf_lock, "klink", 0, LK_CANRECURSE);
     lockinit(&kld_lock, "kldlk", 0, LK_CANRECURSE);
     TAILQ_INIT(&classes);
     TAILQ_INIT(&linker_files);
@@ -496,6 +496,8 @@ linker_file_unload(linker_file_t file)
 	    lockmgr(&llf_lock, LK_RELEASE);
 	    return (0);
     }
+    KASSERT(file->refs == 1,
+	("linker_file_unload: bad reference count %d", file->refs));
 
     KLD_DPF(FILE, ("linker_file_unload: file is unloading, informing modules\n"));
 
@@ -503,9 +505,7 @@ linker_file_unload(linker_file_t file)
      * Inform any modules associated with this file.
      */
     mod = TAILQ_FIRST(&file->modules);
-    for (mod = TAILQ_FIRST(&file->modules); mod; mod = next) {
-	next = module_getfnext(mod);
-
+    while (mod) {
 	/*
 	 * Give the module a chance to veto the unload.  Note that the
 	 * act of unloading the module may cause other modules in the
@@ -517,7 +517,9 @@ linker_file_unload(linker_file_t file)
 	    lockmgr(&llf_lock, LK_RELEASE);
 	    goto out;
 	}
+	next = module_getfnext(mod);
 	module_release(mod);
+	mod = next;
     }
 
     TAILQ_FOREACH_MUTABLE(ml, &found_modules, link, nextml) {
@@ -530,19 +532,15 @@ linker_file_unload(linker_file_t file)
     /* Don't try to run SYSUNINITs if we are unloaded due to a link error */
     if (file->flags & LINKER_FILE_LINKED) {
 	file->flags &= ~LINKER_FILE_LINKED;
-	lockmgr(&llf_lock, LK_RELEASE);
 	linker_file_sysuninit(file);
 	linker_file_unregister_sysctls(file);
-	lockmgr(&llf_lock, LK_EXCLUSIVE);
     }
 
     TAILQ_REMOVE(&linker_files, file, link);
 
     if (file->deps) {
-	lockmgr(&llf_lock, LK_RELEASE);
 	for (i = 0; i < file->ndeps; i++)
 	    linker_file_unload(file->deps[i]);
-	lockmgr(&llf_lock, LK_EXCLUSIVE);
 	kfree(file->deps, M_LINKER);
 	file->deps = NULL;
     }

--- a/sys/kern/kern_linker.c
+++ b/sys/kern/kern_linker.c
@@ -515,7 +515,6 @@ linker_file_unload(linker_file_t file)
 	    KLD_DPF(FILE, ("linker_file_unload: module %p vetoes unload\n",
 			   mod));
 	    lockmgr(&llf_lock, LK_RELEASE);
-	    file->refs--;
 	    goto out;
 	}
 	module_release(mod);


### PR DESCRIPTION
## Summary

Preserve a linker file's reference count when one of its modules vetoes
`MOD_UNLOAD`.

Without this change, every failed `kldunload` decrements `file->refs` even
though the file remains loaded. Repeating an unload that returns `EBUSY`
therefore drives the reference count through zero and into negative values.

## Root cause

Before the 2009 linker update, `linker_file_unload()` temporarily incremented
`file->refs` before notifying modules. The veto path decremented the count to
undo that temporary reference.

The update removed the temporary increment, but retained the decrement in the
veto path. `sys_kldunload()` restores `userrefs` when unload fails, but it does
not restore `refs`, so the stale decrement becomes permanent.

The correct behavior is to leave both reference counts unchanged when the
module remains loaded. This also matches the current FreeBSD implementation,
which returns the module's unload error without changing the linker file
reference count.

## Reproducer

The following standalone KMOD has no device, thread, or external state. It
loads normally and always vetoes `MOD_UNLOAD` with `EBUSY`.

```c
/*-
 * SPDX-License-Identifier: BSD-2-Clause
 */

#include <sys/param.h>
#include <sys/kernel.h>
#include <sys/module.h>
#include <sys/systm.h>

static int
kld_veto_repro_modevent(module_t mod __unused, int type, void *data __unused)
{
	switch (type) {
	case MOD_LOAD:
		kprintf("kld_veto_repro: loaded\n");
		return (0);
	case MOD_UNLOAD:
		kprintf("kld_veto_repro: veto unload\n");
		return (EBUSY);
	default:
		return (EOPNOTSUPP);
	}
}

static moduledata_t kld_veto_repro_module = {
	"kld_veto_repro",
	kld_veto_repro_modevent,
	NULL
};

DECLARE_MODULE(kld_veto_repro, kld_veto_repro_module,
    SI_SUB_DRIVERS, SI_ORDER_ANY);
MODULE_VERSION(kld_veto_repro, 1);
```

```make
KMOD=	kld_veto_repro
SRCS=	kld_veto_repro.c

.include <bsd.kmod.mk>
```

Build the module and run it in a disposable vkernel because it deliberately
refuses to unload:

```text
make
kldload ./kld_veto_repro.ko
kldstat
kldunload kld_veto_repro.ko
kldstat
kldunload kld_veto_repro.ko
kldstat
kldunload kld_veto_repro.ko
kldstat
```

Before the fix, the module's `Refs` column changes after each rejected unload:

```text
initial:              1
first EBUSY:          0
second EBUSY:        -1
third EBUSY:         -2
```

## Fix

Remove the obsolete `file->refs--` from the module-veto path. No reference was
acquired by the current implementation before calling `module_unload()`, so
there is nothing to release when that callback fails.

Compensating in `sys_kldunload()` would be incorrect because
`linker_file_unload()` also has non-syscall callers. The invariant belongs in
`linker_file_unload()` itself: a failed final-reference unload leaves the
reference intact.

## Validation

The reproducer was tested in two VKERNEL64 builds from the same
`069eec1334c1` source baseline. The only source difference was this patch.

- Unmodified vkernel: `1 -> 0 -> -1 -> -2` across three `EBUSY` returns.
- Patched vkernel: `1 -> 1 -> 1 -> 1` across the same three returns.
- The patched VKERNEL64 completed a full `nativekernel` build.
