### PR TITLE
libc: type a positional %F argument in __find_arguments()

### DIFF
--- a/lib/libc/stdio/printf-pos.c
+++ b/lib/libc/stdio/printf-pos.c
@@ -354,6 +354,7 @@ reswitch:	switch (ch) {
 		case 'e':
 		case 'E':
 		case 'f':
+		case 'F':
 		case 'g':
 		case 'G':
 			error = addtype(&types,
@@ -542,6 +543,7 @@ reswitch:	switch (ch) {
 		case 'e':
 		case 'E':
 		case 'f':
+		case 'F':
 		case 'g':
 		case 'G':
 			error = addtype(&types,


### PR DESCRIPTION
__find_arguments() and __find_warguments() in lib/libc/stdio/printf-pos.c
walk a positional format to learn the type of every argument, and list
the floating point conversions as a A e E f g G.  F is not there, so an
argument that only appears as %F never gets a type and the conversion
reads an unset slot of the argument table:

    #include <stdio.h>
    #include <math.h>
    int main(void) {
        printf("[%1$F]\n", -INFINITY);
        printf("[%1$F]\n", 1.5);
        printf("[%F]\n", 1.5);
        return 0;
    }

prints [0.000000], [0.000000], [1.500000] on 6.4.  With a width from a
second argument ("%1$*2$F") vsnprintf(3) returned 8 for a ten character
result.  The same format with %1$f, or with any other conversion of the
same argument, works because those give the argument its type.  abseil's
str_format test compares against the C library and caught it.

The fix adds F next to f in both scanners.  I rebuilt lib/libc from the
DragonFly_RELEASE_6_4 source with this and ran the program above against
the new libc.so.8 through LD_LIBRARY_PATH: it prints [-INF], [1.500000],
[1.500000], and "%1$*2$F" returns 10.  The diff applies to master
unchanged, but I have not built master.

FreeBSD and NetBSD have the same omission and I have reported it there
(freebsd-src #2420, NetBSD lib/60708); OpenBSD's vfprintf.c already has
the F.
