### PR TITLE
libc: reject a negative wchar_t in the UTF-8 encoder

### DIFF
--- a/lib/libc/locale/utf8.c
+++ b/lib/libc/locale/utf8.c
@@ -338,7 +338,7 @@ _UTF8_wcrtomb(char * __restrict s, wchar_t wc, mbstate_t * __restrict ps)
 	} else if ((wc & ~0xffff) == 0) {
 		lead = 0xe0;
 		len = 3;
-	} else if (wc <= 0x10ffff) {
+	} else if (wc >= 0 && wc <= 0x10ffff) {
 		lead = 0xf0;
 		len = 4;
 	} else {
@@ -665,7 +665,7 @@ _UTF8_wcrtombin(char * __restrict dst, const wchar_t * __restrict src,
 			}
 			lead = 0xe0;
 			len = 3;
-		} else if (wc <= 0x10ffff) {
+		} else if (wc >= 0 && wc <= 0x10ffff) {
 			lead = 0xf0;
 			len = 4;
 		} else if ((flags & WCSBIN_LONGCODES) && wc < 0x200000) {


### PR DESCRIPTION
_UTF8_wcrtomb() and _UTF8_wcrtombin() in lib/libc/locale/utf8.c choose
the four byte form with "wc <= 0x10ffff".  wchar_t is signed, so a
negative value passes and gets encoded from its low bits:

    setlocale(LC_ALL, "en_US.UTF-8");
    snprintf(buf, sizeof buf, "%lc", (wint_t)-1);   returns 4, buf = ff bf bf bf
    wcrtomb(mb, (wchar_t)-1, &st);                  returns 4
    wcrtomb(mb, (wchar_t)0x80000000, &st);          returns 4, f0 80 80 80
    wcrtomb(mb, (wchar_t)0x110000, &st);            returns -1, EILSEQ

FreeBSD's utf8.c has "wc >= 0 && wc <= 0x10ffff" at the same place, and
FreeBSD, NetBSD, OpenBSD and macOS all fail the first three with EILSEQ.
abseil's str_format test feeds a negative wchar_t through %lc and
expects the failure, which is how I found it.

The change adds "wc >= 0 &&" to both tests.  I rebuilt lib/libc from
the DragonFly_RELEASE_6_4 source with it and ran the probe against the
new libc.so.8 through LD_LIBRARY_PATH: the three values above fail with
EILSEQ and U+3042 still encodes as e3 81 82.  master has the same file.

(Surrogates such as 0xd800 still encode as ed a0 80; FreeBSD rejects
them too, but that is a separate question and not part of this change.)
